### PR TITLE
EARTH-40: Hide radio and checkbox element behind decorative element.

### DIFF
--- a/css/base/base.css
+++ b/css/base/base.css
@@ -589,7 +589,7 @@ select {
 [type=radio] {
   position: absolute;
   clip-path: inset(10px 20px 30px 40px);
-  clip: rect(0px, 0px, 0px, 0px); }
+  clip: rect(0, 0, 0, 0); }
 
 [type=checkbox] + label,
 [type=radio] + label {

--- a/css/base/base.css
+++ b/css/base/base.css
@@ -587,9 +587,9 @@ select {
 
 [type=checkbox],
 [type=radio] {
-  margin-left: 0.6923076923em;
   position: absolute;
-  z-index: -1; }
+  clip-path: inset(10px 20px 30px 40px);
+  clip: rect(0px, 0px, 0px, 0px); }
 
 [type=checkbox] + label,
 [type=radio] + label {

--- a/css/base/base.css
+++ b/css/base/base.css
@@ -587,8 +587,9 @@ select {
 
 [type=checkbox],
 [type=radio] {
-  margin-left: -1.9230769231em;
-  position: absolute; }
+  margin-left: 0.7692307692em;
+  position: absolute;
+  z-index: -1; }
 
 [type=checkbox] + label,
 [type=radio] + label {

--- a/css/base/base.css
+++ b/css/base/base.css
@@ -587,7 +587,7 @@ select {
 
 [type=checkbox],
 [type=radio] {
-  margin-left: 0.7692307692em;
+  margin-left: 0.6923076923em;
   position: absolute;
   z-index: -1; }
 
@@ -610,7 +610,8 @@ select {
   margin-right: 1.2307692308em;
   text-indent: 0.15em;
   vertical-align: middle\0;
-  width: 1.2307692308em; }
+  width: 1.2307692308em;
+  z-index: 2; }
 
 [type=radio] + label::before {
   border-radius: 100%; }

--- a/scss/base/_forms.scss
+++ b/scss/base/_forms.scss
@@ -59,7 +59,7 @@ select {
 [type=radio] {
   position: absolute;
   clip-path: inset(10px 20px 30px 40px);
-  clip: rect(0px,0px,0px,0px);
+  clip: rect(0, 0, 0, 0);
 }
 
 [type=checkbox] + label,

--- a/scss/base/_forms.scss
+++ b/scss/base/_forms.scss
@@ -57,8 +57,9 @@ select {
 
 [type=checkbox],
 [type=radio] {
-  margin-left: em(-25px); //
+  margin-left: em(10px);
   position: absolute;
+  z-index: -1;
 }
 
 [type=checkbox] + label,

--- a/scss/base/_forms.scss
+++ b/scss/base/_forms.scss
@@ -57,9 +57,9 @@ select {
 
 [type=checkbox],
 [type=radio] {
-  margin-left: em(9px);
   position: absolute;
-  z-index: -1;
+  clip-path: inset(10px 20px 30px 40px);
+  clip: rect(0px,0px,0px,0px);
 }
 
 [type=checkbox] + label,

--- a/scss/base/_forms.scss
+++ b/scss/base/_forms.scss
@@ -57,7 +57,7 @@ select {
 
 [type=checkbox],
 [type=radio] {
-  margin-left: em(10px);
+  margin-left: em(9px);
   position: absolute;
   z-index: -1;
 }
@@ -83,6 +83,7 @@ select {
   text-indent: 0.15em;
   vertical-align: middle\0; // Target IE 11 and below to vertically center inputs
   width: em(16px);
+  z-index: 2;
 }
 
 [type=radio] + label::before {


### PR DESCRIPTION
@slowbot 

What do you think about this to hide the html element behind the decorative element. See screenshots.

![screen shot 2017-06-08 at 10 20 20 am](https://user-images.githubusercontent.com/550602/26941676-28ba6a44-4c34-11e7-87f8-6b4ef1b5170b.png)

vs

![screen shot 2017-06-08 at 10 20 40 am](https://user-images.githubusercontent.com/550602/26941675-28b8cda6-4c34-11e7-8fe4-ea7006737744.png)
