### PR TITLE
EARTH-164: Highlight Banner

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -1724,6 +1724,148 @@
   display: block;
   z-index: 2; }
 
+.highlight-card {
+  box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
+  padding: 2.3076923077em; }
+  .highlight-card p {
+    color: #9c9d9e;
+    letter-spacing: .5px;
+    line-height: 2em; }
+
+.highlight-card__action {
+  color: #4d4f53; }
+  .highlight-card__action:hover, .highlight-card__action:active, .highlight-card__action:focus {
+    color: inherit;
+    text-decoration: none; }
+    .highlight-card__action:hover .highlight-card__title, .highlight-card__action:active .highlight-card__title, .highlight-card__action:focus .highlight-card__title {
+      color: #016779; }
+    .highlight-card__action:hover .highlight-card__arrow svg use, .highlight-card__action:active .highlight-card__arrow svg use, .highlight-card__action:focus .highlight-card__arrow svg use {
+      fill: #9c9d9e; }
+
+.highlight-card__intro {
+  color: #f9b002;
+  display: block;
+  font-size: 0.9230769231em;
+  letter-spacing: .9px;
+  margin-bottom: 1em;
+  text-transform: uppercase; }
+
+.highlight-card__title {
+  font-size: 2em;
+  letter-spacing: .3px; }
+
+.highlight-card__arrow svg use {
+  fill: #8c1515; }
+
+.section-highlight-banner {
+  background-color: #333;
+  color: #fff; }
+  .section-highlight-banner:before {
+    content: '';
+    display: block;
+    background-color: rgba(0, 0, 0, 0.5);
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    z-index: 1; }
+    @media only screen and (min-width: 1024px) {
+      .section-highlight-banner:before {
+        top: 45px;
+        bottom: 45px; } }
+  @media only screen and (min-width: 1024px) {
+    .section-highlight-banner.is-single:before {
+      left: calc(50% - (450px - 30px));
+      right: calc(50% - (450px - 30px));
+      top: 0;
+      bottom: 0; } }
+  .section-highlight-banner .section-header .drop-cap-title__name {
+    color: #fff; }
+  .section-highlight-banner .section-header .drop-cap-title__drop-cap {
+    opacity: .35; }
+
+@keyframes fadein {
+  from {
+    opacity: 0; }
+  to {
+    opacity: 1; } }
+
+@-moz-keyframes fadein {
+  from {
+    opacity: 0; }
+  to {
+    opacity: 1; } }
+
+@-webkit-keyframes fadein {
+  from {
+    opacity: 0; }
+  to {
+    opacity: 1; } }
+
+@-ms-keyframes fadein {
+  from {
+    opacity: 0; }
+  to {
+    opacity: 1; } }
+
+@-o-keyframes fadein {
+  from {
+    opacity: 0; }
+  to {
+    opacity: 1; } }
+
+.has-image-overlay {
+  position: relative; }
+  .has-image-overlay::before {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: rgba(0, 0, 0, 0.35);
+    content: "";
+    display: block; }
+  .has-image-overlay img {
+    display: block; }
+
+.has-image-gradient {
+  position: relative; }
+  .has-image-gradient::before {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
+    content: "";
+    display: block; }
+  .has-image-gradient img {
+    display: block; }
+
+.responsive-video-container {
+  overflow: hidden;
+  position: relative;
+  padding-bottom: 56.25%;
+  padding-top: 2em;
+  height: 0; }
+  .responsive-video-container iframe,
+  .responsive-video-container object,
+  .responsive-video-container embed {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%; }
+
+.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+  position: absolute;
+  height: 2px;
+  width: 20px;
+  content: '';
+  display: block;
+  z-index: 2; }
+
 .navbar {
   position: absolute;
   top: 0;

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -1760,7 +1760,7 @@
 .section-highlight-banner {
   background-color: #333;
   color: #fff; }
-  .section-highlight-banner:before {
+  .section-highlight-banner::before {
     content: '';
     display: block;
     background-color: rgba(0, 0, 0, 0.5);
@@ -1771,11 +1771,11 @@
     bottom: 0;
     z-index: 1; }
     @media only screen and (min-width: 1024px) {
-      .section-highlight-banner:before {
+      .section-highlight-banner::before {
         top: 45px;
         bottom: 45px; } }
   @media only screen and (min-width: 1024px) {
-    .section-highlight-banner.is-single:before {
+    .section-highlight-banner.is-single::before {
       left: calc(50% - (450px - 30px));
       right: calc(50% - (450px - 30px));
       top: 0;

--- a/scss/components/components.scss
+++ b/scss/components/components.scss
@@ -40,6 +40,7 @@
   "global-footer/global-footer",
   "header/header",
   "hero-banner/hero-banner",
+  "highlight-banner/highlight-banner",
   "navbar/navbar",
   "navigation/navigation",
   "postcard/postcard",

--- a/scss/components/highlight-banner/_highlight-banner.scss
+++ b/scss/components/highlight-banner/_highlight-banner.scss
@@ -11,7 +11,7 @@
 
 .highlight-card {
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
-  
+
   padding: em(30px);
 
   p {
@@ -23,7 +23,7 @@
 
 .highlight-card__action {
   color: color(text-active);
-  
+
   @include on-event {
     color: inherit;
     text-decoration: none;
@@ -37,7 +37,7 @@
         fill: color(ash);
       }
     }
-  } 
+  }
 }
 
 .highlight-card__intro {
@@ -65,7 +65,7 @@
   background-color: #333;
   color: color(white);
 
-  &:before {
+  &::before {
     content: '';
     display: block;
     background-color: rgba(0, 0, 0, .5);
@@ -79,12 +79,12 @@
     @include grid-media($media-lg) {
       top: 45px;
       bottom: 45px;
-    }  
+    }
   }
 
   // If single card apply new background offset
   &.is-single {
-    &:before {
+    &::before {
       @include grid-media($media-lg) {
         left: calc(50% - (450px - 30px));
         right: calc(50% - (450px - 30px));

--- a/scss/components/highlight-banner/_highlight-banner.scss
+++ b/scss/components/highlight-banner/_highlight-banner.scss
@@ -11,7 +11,6 @@
 
 .highlight-card {
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
-
   padding: em(30px);
 
   p {
@@ -55,7 +54,6 @@
 }
 
 .highlight-card__arrow {
-
   svg use {
     fill: color(brand);
   }

--- a/scss/components/highlight-banner/_highlight-banner.scss
+++ b/scss/components/highlight-banner/_highlight-banner.scss
@@ -1,0 +1,106 @@
+@charset 'UTF-8';
+
+// My Config.
+@import "config/config";
+
+// Decanter config.
+@import "decanter/core/utilities/decanter-utilities";
+
+// Grab our mixins.
+@import "utilities/utilities";
+
+.highlight-card {
+  box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
+  
+  padding: em(30px);
+
+  p {
+    color: color(ash);
+    letter-spacing: .5px;
+    line-height: 2em;
+  }
+}
+
+.highlight-card__action {
+  color: color(text-active);
+  
+  @include on-event {
+    color: inherit;
+    text-decoration: none;
+
+    .highlight-card__title {
+      color: color(action-active);
+    }
+
+    .highlight-card__arrow {
+      svg use {
+        fill: color(ash);
+      }
+    }
+  } 
+}
+
+.highlight-card__intro {
+  color: color(emphasis);
+  display: block;
+  font-size: em(12px);
+  letter-spacing: .9px;
+  margin-bottom: 1em;
+  text-transform: uppercase;
+}
+
+.highlight-card__title {
+  font-size: em(26px);
+  letter-spacing: .3px;
+}
+
+.highlight-card__arrow {
+
+  svg use {
+    fill: color(brand);
+  }
+}
+
+.section-highlight-banner {
+  background-color: #333;
+  color: color(white);
+
+  &:before {
+    content: '';
+    display: block;
+    background-color: rgba(0, 0, 0, .5);
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    z-index: 1;
+
+    @include grid-media($media-lg) {
+      top: 45px;
+      bottom: 45px;
+    }  
+  }
+
+  // If single card apply new background offset
+  &.is-single {
+    &:before {
+      @include grid-media($media-lg) {
+        left: calc(50% - (450px - 30px));
+        right: calc(50% - (450px - 30px));
+        top: 0;
+        bottom: 0;
+      }
+    }
+  }
+
+  .section-header {
+    .drop-cap-title__name {
+      color: color(white);
+    }
+
+    .drop-cap-title__drop-cap {
+      opacity: .35;
+    }
+  }
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Creation of highlight banner component and nested components. 
1. Highlight card. Single course card with title, description and link
2. Highlight cards. Container for single or multiple cards
3. Highlight banner. Full screen container with background image, title, and overlay

# Needed By next week

# Steps to Test

1. Download complimentary branch from stanford component EARTH-164-info-card
2. Review single highlight card and preview theme styles
3. Review highlight-cards and preview how multiple cards interact. Test responsiveness.
4. Review section-highlight-banner and preview how cards relate to header and background image. 
5. In section-highlight-banner yml file comment out one card and mark is_single to true.
6. Refresh section-highlight-banner in browser and see how layout elements adapt to one card being present.

# Associated Issues and/or People
- JIRA ticket EARTH-164
- See complimentary branch in stanford components EARTH-164-info-card
- Please review implementation of flexbox. Also review implementation of is-single class to section-highlight-banner. Not sure how this would be controlled from the CMS.
- @sherakama 

