### PR TITLE
EARTH-178: Resolving footer overflow

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -1415,15 +1415,15 @@
   @media only screen and (min-width: 768px) {
     #footer__global-footer #global-footer__nav,
     #footer__global-footer #global-footer__info {
-      margin-left: 9.6153846154em; } }
+      padding-left: 9.6153846154em; } }
   @media only screen and (min-width: 1024px) {
     #footer__global-footer #global-footer__nav,
     #footer__global-footer #global-footer__info {
-      margin-left: 12.6923076923em; } }
+      padding-left: 12.6923076923em; } }
   @media only screen and (min-width: 1500px) {
     #footer__global-footer #global-footer__nav,
     #footer__global-footer #global-footer__info {
-      margin-left: 16.9230769231em; } }
+      padding-left: 16.9230769231em; } }
 
 @media only screen and (min-width: 768px) {
   .contact-footer .block--lockup__site-slogan {

--- a/scss/components/global-footer/_global-footer.scss
+++ b/scss/components/global-footer/_global-footer.scss
@@ -149,15 +149,15 @@
   #global-footer__nav,
   #global-footer__info {
     @include grid-media($media-md) {
-      margin-left: em(125px);
+      padding-left: em(125px);
     }
 
     @include grid-media($media-lg) {
-      margin-left: em(165px);
+      padding-left: em(165px);
     }
 
     @include grid-media($media-xl) {
-      margin-left: em(220px);
+      padding-left: em(220px);
     }
   }
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixing footer overflow bug. Offsetting elements using padding instead of margins to prevent overflow.

# Needed By ASAP

# Steps to Test

1. Go to any page on the site and use Google dev tools to preview the site on iPad

# Associated Issues and/or People
- JIRA ticket EARTH-178
- @nickmanning @sherakama 
