### PR TITLE
EARTH-262: Fixing firefox issues with simple block and masonry block

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -1958,11 +1958,12 @@
 
 .highlight-card {
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
-  padding: 2.3076923077em; }
+  padding: 30px 30px 20px; }
   .highlight-card p {
     color: #9c9d9e;
     letter-spacing: .5px;
-    line-height: 2em; }
+    line-height: 2em;
+    margin-bottom: .5em; }
 
 .highlight-card__action {
   color: #4d4f53; }
@@ -1986,8 +1987,10 @@
   font-size: 2em;
   letter-spacing: .3px; }
 
-.highlight-card__arrow svg use {
-  fill: #8c1515; }
+.highlight-card__arrow {
+  height: 25px; }
+  .highlight-card__arrow svg use {
+    fill: #8c1515; }
 
 .section-highlight-banner {
   background-color: #333;
@@ -3624,6 +3627,9 @@
   .simple-block__link:hover, .simple-block__link:active, .simple-block__link:focus {
     color: inherit;
     text-decoration: none; }
+
+.simple-block__thumbnail {
+  margin-bottom: .5em; }
 
 .simple-block__tag {
   background-color: rgba(0, 0, 0, 0.5);

--- a/scss/components/highlight-banner/_highlight-banner.scss
+++ b/scss/components/highlight-banner/_highlight-banner.scss
@@ -11,12 +11,13 @@
 
 .highlight-card {
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
-  padding: em(30px);
+  padding: 30px 30px 20px;
 
   p {
     color: color(ash);
     letter-spacing: .5px;
     line-height: 2em;
+    margin-bottom: .5em;
   }
 }
 
@@ -54,6 +55,8 @@
 }
 
 .highlight-card__arrow {
+  height: 25px;
+  
   svg use {
     fill: color(brand);
   }

--- a/scss/components/highlight-banner/_highlight-banner.scss
+++ b/scss/components/highlight-banner/_highlight-banner.scss
@@ -56,7 +56,7 @@
 
 .highlight-card__arrow {
   height: 25px;
-  
+
   svg use {
     fill: color(brand);
   }

--- a/scss/components/simple-block/_simple-block.scss
+++ b/scss/components/simple-block/_simple-block.scss
@@ -18,6 +18,10 @@
   }
 }
 
+.simple-block__thumbnail {
+  margin-bottom: .5em;
+}
+
 .simple-block__tag {
   background-color: rgba(0, 0, 0, 0.5);
   padding: .625em 1em;


### PR DESCRIPTION
READY FOR REVIEW

Fixes images overflowing on Firefox due to display: inline-block rule.
Also adds max width for images in masonry-blocks on mobile which was also breaking in FF. 
Includes some smaller styles fixes and updates.

See complimentary Stanford Component branch EARTH-262

@sherakama 