### PR TITLE
EARTH-242: Hiding navbar with css on mobile

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -2653,7 +2653,7 @@
     position: relative; } }
 
 .navbar__group {
-  display: block;
+  display: none;
   padding-bottom: 5em;
   padding-top: 8.4615384615em; }
   @media only screen and (min-width: 860px) {

--- a/scss/components/navbar/_navbar.scss
+++ b/scss/components/navbar/_navbar.scss
@@ -38,7 +38,7 @@ $nav-bar-height: em(65px);
 }
 
 .navbar__group {
-  display: block;
+  display: none;
   padding-bottom: $nav-bar-height;
   padding-top: em(110px);
 


### PR DESCRIPTION
READY FOR REVIEW

Hiding navbar with css rather than relying on js.

Fixes EARTH-263 and EARTH-179.