### PR TITLE
EARTH-32: Adds matson theme Quote Card component

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -642,29 +642,37 @@
   z-index: 2; }
 
 .quote-card {
-  box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
-  padding: 2.3076923077em 7.6923076923em; }
+  box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1); }
   .quote-card p {
     color: #9c9d9e; }
 
 .quote-card__icon {
-  color: #8c1414;
-  position: relative;
-  left: -60px;
-  top: 30px; }
+  color: #8c1414; }
   .quote-card__icon svg {
     height: 19px;
     width: 29px; }
 
-.quote-card__quote {
+.quote-card__quote p {
+  font-weight: 200;
   font-size: 2em;
   letter-spacing: .5px;
   line-height: 1.3em; }
 
 .quote-card__source {
-  border: 0.2307692308em; }
-  .quote-card__source h3 {
+  position: relative; }
+  .quote-card__source::before {
+    background-color: #D8D8D8;
+    content: '';
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 70px;
+    height: 1px; }
+  .quote-card__source strong {
     color: #8c1414;
+    display: block;
+    font-style: normal;
     font-size: 0.9230769231em;
     letter-spacing: .9px;
     text-transform: uppercase; }

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -643,6 +643,7 @@
 
 .quote-card {
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
+  margin: 5.0769230769em auto;
   padding: 2.3076923077em 7.6923076923em; }
   .quote-card p {
     color: #9c9d9e; }

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -589,36 +589,6 @@
     position: absolute;
     top: 35%; }
 
-@keyframes fadein {
-  from {
-    opacity: 0; }
-  to {
-    opacity: 1; } }
-
-@-moz-keyframes fadein {
-  from {
-    opacity: 0; }
-  to {
-    opacity: 1; } }
-
-@-webkit-keyframes fadein {
-  from {
-    opacity: 0; }
-  to {
-    opacity: 1; } }
-
-@-ms-keyframes fadein {
-  from {
-    opacity: 0; }
-  to {
-    opacity: 1; } }
-
-@-o-keyframes fadein {
-  from {
-    opacity: 0; }
-  to {
-    opacity: 1; } }
-
 .has-image-overlay {
   position: relative; }
   .has-image-overlay::before {
@@ -673,36 +643,31 @@
 
 .quote-card {
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
-  padding: 2.3076923077em; }
+  padding: 2.3076923077em 7.6923076923em; }
   .quote-card p {
-    color: #9c9d9e;
-    letter-spacing: .5px;
-    line-height: 2em; }
+    color: #9c9d9e; }
 
-.quote-card__action {
-  color: #4d4f53; }
-  .quote-card__action:hover, .quote-card__action:active, .quote-card__action:focus {
-    color: inherit;
-    text-decoration: none; }
-    .quote-card__action:hover .quote-card__title, .quote-card__action:active .quote-card__title, .quote-card__action:focus .quote-card__title {
-      color: #016779; }
-    .quote-card__action:hover .quote-card__arrow svg use, .quote-card__action:active .quote-card__arrow svg use, .quote-card__action:focus .quote-card__arrow svg use {
-      fill: #9c9d9e; }
+.quote-card__icon {
+  color: #8c1414;
+  position: relative;
+  left: -60px;
+  top: 30px; }
+  .quote-card__icon svg {
+    height: 19px;
+    width: 29px; }
 
-.quote-card__intro {
-  color: #f9b002;
-  display: block;
-  font-size: 0.9230769231em;
-  letter-spacing: .9px;
-  margin-bottom: 1em;
-  text-transform: uppercase; }
-
-.quote-card__title {
+.quote-card__quote {
   font-size: 2em;
-  letter-spacing: .3px; }
+  letter-spacing: .5px;
+  line-height: 1.3em; }
 
-.quote-card__arrow svg use {
-  fill: #8c1515; }
+.quote-card__source {
+  border: 0.2307692308em; }
+  .quote-card__source h3 {
+    color: #8c1414;
+    font-size: 0.9230769231em;
+    letter-spacing: .9px;
+    text-transform: uppercase; }
 
 .contact-footer {
   background-size: cover;

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -589,6 +589,121 @@
     position: absolute;
     top: 35%; }
 
+@keyframes fadein {
+  from {
+    opacity: 0; }
+  to {
+    opacity: 1; } }
+
+@-moz-keyframes fadein {
+  from {
+    opacity: 0; }
+  to {
+    opacity: 1; } }
+
+@-webkit-keyframes fadein {
+  from {
+    opacity: 0; }
+  to {
+    opacity: 1; } }
+
+@-ms-keyframes fadein {
+  from {
+    opacity: 0; }
+  to {
+    opacity: 1; } }
+
+@-o-keyframes fadein {
+  from {
+    opacity: 0; }
+  to {
+    opacity: 1; } }
+
+.has-image-overlay {
+  position: relative; }
+  .has-image-overlay::before {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: rgba(0, 0, 0, 0.35);
+    content: "";
+    display: block;
+    z-index: 1; }
+  .has-image-overlay img {
+    display: block; }
+
+.has-image-gradient {
+  position: relative; }
+  .has-image-gradient::before {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
+    content: "";
+    display: block; }
+  .has-image-gradient img {
+    display: block; }
+
+.responsive-video-container {
+  overflow: hidden;
+  position: relative;
+  padding-bottom: 56.25%;
+  padding-top: 2em;
+  height: 0; }
+  .responsive-video-container iframe,
+  .responsive-video-container object,
+  .responsive-video-container embed {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%; }
+
+.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+  position: absolute;
+  height: 2px;
+  width: 20px;
+  content: '';
+  display: block;
+  z-index: 2; }
+
+.quote-card {
+  box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
+  padding: 2.3076923077em; }
+  .quote-card p {
+    color: #9c9d9e;
+    letter-spacing: .5px;
+    line-height: 2em; }
+
+.quote-card__action {
+  color: #4d4f53; }
+  .quote-card__action:hover, .quote-card__action:active, .quote-card__action:focus {
+    color: inherit;
+    text-decoration: none; }
+    .quote-card__action:hover .quote-card__title, .quote-card__action:active .quote-card__title, .quote-card__action:focus .quote-card__title {
+      color: #016779; }
+    .quote-card__action:hover .quote-card__arrow svg use, .quote-card__action:active .quote-card__arrow svg use, .quote-card__action:focus .quote-card__arrow svg use {
+      fill: #9c9d9e; }
+
+.quote-card__intro {
+  color: #f9b002;
+  display: block;
+  font-size: 0.9230769231em;
+  letter-spacing: .9px;
+  margin-bottom: 1em;
+  text-transform: uppercase; }
+
+.quote-card__title {
+  font-size: 2em;
+  letter-spacing: .3px; }
+
+.quote-card__arrow svg use {
+  fill: #8c1515; }
+
 .contact-footer {
   background-size: cover;
   background-color: #1C1E23;

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -643,7 +643,6 @@
 
 .quote-card {
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
-  margin: 5.0769230769em auto;
   padding: 2.3076923077em 7.6923076923em; }
   .quote-card p {
     color: #9c9d9e; }

--- a/scss/components/components.scss
+++ b/scss/components/components.scss
@@ -32,6 +32,7 @@
   "calendar-block/calendar-block",
   "callout-block/callout-block",
   "callout-card/callout-card",
+  "quote-card/quote-card",
   "contact-footer/contact-footer",
   "collapsible-menu/collapsible-menu",
   "drop-cap/drop-cap",

--- a/scss/components/quote-card/_quote-card.scss
+++ b/scss/components/quote-card/_quote-card.scss
@@ -1,0 +1,60 @@
+@charset 'UTF-8';
+
+// My Config.
+@import "config/config";
+
+// Decanter config.
+@import "decanter/core/utilities/decanter-utilities";
+
+// Grab our mixins.
+@import "utilities/utilities";
+
+.quote-card {
+  box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
+  padding: em(30px);
+
+  p {
+    color: color(ash);
+    letter-spacing: .5px;
+    line-height: 2em;
+  }
+}
+
+.quote-card__action {
+  color: color(text-active);
+
+  @include on-event {
+    color: inherit;
+    text-decoration: none;
+
+    .quote-card__title {
+      color: color(action-active);
+    }
+
+    .quote-card__arrow {
+      svg use {
+        fill: color(ash);
+      }
+    }
+  }
+}
+
+.quote-card__intro {
+  color: color(emphasis);
+  display: block;
+  font-size: em(12px);
+  letter-spacing: .9px;
+  margin-bottom: 1em;
+  text-transform: uppercase;
+}
+
+.quote-card__title {
+  font-size: em(26px);
+  letter-spacing: .3px;
+}
+
+.quote-card__arrow {
+  svg use {
+    fill: color(brand);
+  }
+}

--- a/scss/components/quote-card/_quote-card.scss
+++ b/scss/components/quote-card/_quote-card.scss
@@ -11,50 +11,42 @@
 
 .quote-card {
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
-  padding: em(30px);
+  padding: em(30px) em(100px);
 
   p {
     color: color(ash);
-    letter-spacing: .5px;
-    line-height: 2em;
   }
+
 }
 
-.quote-card__action {
-  color: color(text-active);
+.quote-card__icon {
+  color: color(dark-red);
+  position: relative;
+  left: -60px;
+  top: 30px;
 
-  @include on-event {
-    color: inherit;
-    text-decoration: none;
-
-    .quote-card__title {
-      color: color(action-active);
-    }
-
-    .quote-card__arrow {
-      svg use {
-        fill: color(ash);
-      }
-    }
+  svg {
+    height: 19px;
+    width: 29px;
   }
+
 }
 
-.quote-card__intro {
-  color: color(emphasis);
-  display: block;
-  font-size: em(12px);
-  letter-spacing: .9px;
-  margin-bottom: 1em;
-  text-transform: uppercase;
-}
-
-.quote-card__title {
+.quote-card__quote {
   font-size: em(26px);
-  letter-spacing: .3px;
+  letter-spacing: .5px;
+  line-height: 1.3em;
 }
 
-.quote-card__arrow {
-  svg use {
-    fill: color(brand);
+.quote-card__source {
+
+  border: em(3px);
+
+  h3 {
+    color: color(dark-red);
+    font-size: em(12px);
+    letter-spacing: .9px;
+    text-transform: uppercase;
   }
+
 }

--- a/scss/components/quote-card/_quote-card.scss
+++ b/scss/components/quote-card/_quote-card.scss
@@ -11,6 +11,7 @@
 
 .quote-card {
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
+  margin: em(66px) auto;
   padding: em(30px) em(100px);
 
   p {

--- a/scss/components/quote-card/_quote-card.scss
+++ b/scss/components/quote-card/_quote-card.scss
@@ -11,42 +11,50 @@
 
 .quote-card {
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
-  padding: em(30px) em(100px);
 
   p {
     color: color(ash);
   }
-
 }
 
 .quote-card__icon {
   color: color(dark-red);
-  position: relative;
-  left: -60px;
-  top: 30px;
 
   svg {
     height: 19px;
     width: 29px;
   }
-
 }
 
 .quote-card__quote {
-  font-size: em(26px);
-  letter-spacing: .5px;
-  line-height: 1.3em;
+  p {
+    font-weight: 200;
+    font-size: em(26px);
+    letter-spacing: .5px;
+    line-height: 1.3em;
+  }
 }
 
 .quote-card__source {
+  position: relative;
 
-  border: em(3px);
+  &::before {
+    background-color: color(smoke);
+    content: '';
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 70px;
+    height: 1px;
+  }
 
-  h3 {
+  strong {
     color: color(dark-red);
+    display: block;
+    font-style: normal;
     font-size: em(12px);
     letter-spacing: .9px;
     text-transform: uppercase;
   }
-
 }

--- a/scss/components/quote-card/_quote-card.scss
+++ b/scss/components/quote-card/_quote-card.scss
@@ -11,7 +11,6 @@
 
 .quote-card {
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
-  margin: em(66px) auto;
   padding: em(30px) em(100px);
 
   p {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adds theme specific style for Quote Banner.

# Needed By (Date)
- Next Sprint

# Steps to Test

1. View photo banner component here: /patterns#photo_banner
2. View quote card component here: /patterns#quote_card
3. View full Quote Banner component here: /patterns#section_quote_banner

# Affected versions or modules
- n/a

# Associated Issues and/or People
- JIRA ticket EARTH-32
- Other PRs: https://github.com/SU-SWS/stanford_components/pull/36
- People: @sherakama 
