### PR TITLE
EARTH-140: Adding styles for additional tiles and quotes

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -2758,7 +2758,7 @@
     width: 190px;
     border: 1px solid #D8D8D8;
     top: 100px;
-    right: 100px;
+    left: 100px;
     z-index: -1; }
     @media only screen and (min-width: 1024px) {
       .photo-tiles .photo-tile::after {

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -2797,7 +2797,7 @@
     font-style: normal;
     position: relative;
     padding-top: 1em; }
-    .photo-tiles__quote cite:before {
+    .photo-tiles__quote cite::before {
       position: absolute;
       content: '';
       height: 1px;

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -2748,6 +2748,22 @@
   display: block;
   z-index: 2; }
 
+.photo-tiles .photo-tile {
+  position: relative; }
+  .photo-tiles .photo-tile::after {
+    content: '';
+    display: none;
+    position: absolute;
+    height: 190px;
+    width: 190px;
+    border: 1px solid #D8D8D8;
+    top: 100px;
+    right: 100px;
+    z-index: -1; }
+    @media only screen and (min-width: 1024px) {
+      .photo-tiles .photo-tile::after {
+        display: block; } }
+
 .photo-tile__title {
   letter-spacing: .3px;
   position: relative;
@@ -2766,6 +2782,41 @@
 .photo-tile__description {
   letter-spacing: .5px;
   margin-bottom: 4px; }
+
+.photo-tiles__quote {
+  padding-top: 3em;
+  position: relative;
+  color: #9c9d9e; }
+  .photo-tiles__quote > * {
+    letter-spacing: .5px;
+    line-height: 1.5em; }
+  .photo-tiles__quote blockquote {
+    margin: 0; }
+  .photo-tiles__quote cite {
+    display: block;
+    font-style: normal;
+    position: relative;
+    padding-top: 1em; }
+    .photo-tiles__quote cite:before {
+      position: absolute;
+      content: '';
+      height: 1px;
+      width: 70px;
+      background-color: #9c9d9e;
+      top: 0; }
+  .photo-tiles__quote strong {
+    display: block;
+    font-size: 0.9230769231em;
+    color: #8c1515;
+    text-transform: uppercase; }
+  .photo-tiles__quote svg {
+    position: absolute;
+    display: block;
+    margin-bottom: 1em;
+    top: 0;
+    left: 0; }
+    .photo-tiles__quote svg use {
+      fill: #8c1515; }
 
 .has-image-overlay {
   position: relative; }

--- a/scss/components/photo-tile/_photo-tile.scss
+++ b/scss/components/photo-tile/_photo-tile.scss
@@ -9,6 +9,28 @@
 // Grab our mixins.
 @import "utilities/utilities";
 
+.photo-tiles {
+  .photo-tile {
+    position: relative;
+
+    &::after {
+      content: '';
+      display: none;
+      position: absolute;
+      height: 190px;
+      width: 190px;
+      border: 1px solid color(smoke);
+      top: 100px;
+      right: 100px;
+      z-index: -1;
+
+      @include grid-media($media-lg) {
+        display: block;
+      }
+    }
+  }
+}
+
 .photo-tile__title {
   letter-spacing: .3px;
   position: relative;
@@ -30,4 +52,54 @@
 .photo-tile__description {
   letter-spacing: .5px;
   margin-bottom: 4px;
+}
+
+.photo-tiles__quote {
+  padding-top: 3em;
+  position: relative;
+  color: color(ash);
+
+  > * {
+    letter-spacing: .5px;
+    line-height: 1.5em;
+  }
+
+  blockquote {
+    margin: 0;
+  }
+
+  cite {
+    display: block;
+    font-style: normal;
+    position: relative;
+    padding-top: 1em;
+
+    &:before {
+      position: absolute;
+      content: '';
+      height: 1px;
+      width: 70px;
+      background-color: color(ash);
+      top: 0;
+    }
+  }
+
+  strong {
+    display: block;
+    font-size: em(12px);
+    color: color(brand);
+    text-transform: uppercase;
+  }
+
+  svg {
+    position: absolute;
+    display: block;
+    margin-bottom: 1em;
+    top: 0;
+    left: 0;
+
+    use {
+      fill: color(brand);
+    }
+  }
 }

--- a/scss/components/photo-tile/_photo-tile.scss
+++ b/scss/components/photo-tile/_photo-tile.scss
@@ -21,7 +21,7 @@
       width: 190px;
       border: 1px solid color(smoke);
       top: 100px;
-      right: 100px;
+      left: 100px;
       z-index: -1;
 
       @include grid-media($media-lg) {

--- a/scss/components/photo-tile/_photo-tile.scss
+++ b/scss/components/photo-tile/_photo-tile.scss
@@ -74,7 +74,7 @@
     position: relative;
     padding-top: 1em;
 
-    &:before {
+    &::before {
       position: absolute;
       content: '';
       height: 1px;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Updating existing components and adding additional organism for more complex photo-mosaic with additional quote elements.
1. molecules/photo-tiles: adding styles for blockquote and decorative background element
2. organisms/section-photo-mosaic-quotes: adding styles for additional photo-tiles classes 

# Needed By next sprint

# Steps to Test
1. Download complimentary stanford components branch EARTH-140-photo-tiles-extension
2. Review updated molecules/photo-tiles. Added background decoration
3. Review updated organisms/section-photo-mosaic. Added background decorations
4. Review updated organisms/section-photo-mosaic-quotes. Added background decorations. Add blockquote elements. Preview responsiveness
a. photo-mosaic--thumbs-up
b. photo-mosaic--thumbs-down .is-right
d. photo-mosaic--thumbs-down-alt 
c. photo-mosaic--thumbs-down-quote .is-right

# Associated Issues and/or People
- JIRA ticket EARTH-140-photo-tiles-extension
- Download complimentary stanford components branch EARTH-140-photo-tiles-extension. Each of the photo-tiles layouts has a special grid class. 
- @sherakama
