### PR TITLE
EARTH-282: Setting up multi column masonry cards

### DIFF
--- a/css/base/base.css
+++ b/css/base/base.css
@@ -43,7 +43,7 @@ html {
 
 .button,
 .button__primary, .button__primary--expanded,
-.button__secondary, .button__secondary--expanded, button, [type='button'], [type='reset'], [type='submit'], .button__hollow, .button__hollow--expanded {
+.button__secondary, .button__secondary--expanded, button, [type='button'], [type='reset'], [type='submit'], .button__hollow, .button__hollow--white, .button__hollow--expanded {
   /*!*/
   box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.1), 0px 0px 5px rgba(0, 0, 0, 0.1);
   appearance: none;
@@ -65,28 +65,28 @@ html {
   transition: all 250ms ease-in-out; }
   .button:hover,
   .button__primary:hover, .button__primary--expanded:hover,
-  .button__secondary:hover, .button__secondary--expanded:hover, button:hover, [type='button']:hover, [type='reset']:hover, [type='submit']:hover, .button__hollow:hover, .button__hollow--expanded:hover, .button:active,
+  .button__secondary:hover, .button__secondary--expanded:hover, button:hover, [type='button']:hover, [type='reset']:hover, [type='submit']:hover, .button__hollow:hover, .button__hollow--white:hover, .button__hollow--expanded:hover, .button:active,
   .button__primary:active, .button__primary--expanded:active,
-  .button__secondary:active, .button__secondary--expanded:active, button:active, [type='button']:active, [type='reset']:active, [type='submit']:active, .button__hollow:active, .button__hollow--expanded:active, .button:focus,
+  .button__secondary:active, .button__secondary--expanded:active, button:active, [type='button']:active, [type='reset']:active, [type='submit']:active, .button__hollow:active, .button__hollow--white:active, .button__hollow--expanded:active, .button:focus,
   .button__primary:focus, .button__primary--expanded:focus,
-  .button__secondary:focus, .button__secondary--expanded:focus, button:focus, [type='button']:focus, [type='reset']:focus, [type='submit']:focus, .button__hollow:focus, .button__hollow--expanded:focus {
+  .button__secondary:focus, .button__secondary--expanded:focus, button:focus, [type='button']:focus, [type='reset']:focus, [type='submit']:focus, .button__hollow:focus, .button__hollow--white:focus, .button__hollow--expanded:focus {
     background-color: #33548F;
     color: #dceefe;
     text-decoration: none; }
   .button:disabled,
   .button__primary:disabled, .button__primary--expanded:disabled,
-  .button__secondary:disabled, .button__secondary--expanded:disabled, button:disabled, [type='button']:disabled, [type='reset']:disabled, [type='submit']:disabled, .button__hollow:disabled, .button__hollow--expanded:disabled, .disabled.button,
+  .button__secondary:disabled, .button__secondary--expanded:disabled, button:disabled, [type='button']:disabled, [type='reset']:disabled, [type='submit']:disabled, .button__hollow:disabled, .button__hollow--white:disabled, .button__hollow--expanded:disabled, .disabled.button,
   .disabled.button__primary, .disabled.button__primary--expanded,
-  .disabled.button__secondary, .disabled.button__secondary--expanded, button.disabled, .disabled[type='button'], .disabled[type='reset'], .disabled[type='submit'], .disabled.button__hollow, .disabled.button__hollow--expanded {
+  .disabled.button__secondary, .disabled.button__secondary--expanded, button.disabled, .disabled[type='button'], .disabled[type='reset'], .disabled[type='submit'], .disabled.button__hollow, .disabled.button__hollow--white, .disabled.button__hollow--expanded {
     background-color: #006cb8;
     color: #fff;
     cursor: not-allowed;
     opacity: 0.5; }
     .button:disabled:hover,
     .button__primary:disabled:hover, .button__primary--expanded:disabled:hover,
-    .button__secondary:disabled:hover, .button__secondary--expanded:disabled:hover, button:disabled:hover, [type='button']:disabled:hover, [type='reset']:disabled:hover, [type='submit']:disabled:hover, .button__hollow:disabled:hover, .button__hollow--expanded:disabled:hover, .disabled.button:hover,
+    .button__secondary:disabled:hover, .button__secondary--expanded:disabled:hover, button:disabled:hover, [type='button']:disabled:hover, [type='reset']:disabled:hover, [type='submit']:disabled:hover, .button__hollow:disabled:hover, .button__hollow--white:disabled:hover, .button__hollow--expanded:disabled:hover, .disabled.button:hover,
     .disabled.button__primary:hover, .disabled.button__primary--expanded:hover,
-    .disabled.button__secondary:hover, .disabled.button__secondary--expanded:hover, button.disabled:hover, .disabled[type='button']:hover, .disabled[type='reset']:hover, .disabled[type='submit']:hover, .disabled.button__hollow:hover, .disabled.button__hollow--expanded:hover {
+    .disabled.button__secondary:hover, .disabled.button__secondary--expanded:hover, button.disabled:hover, .disabled[type='button']:hover, .disabled[type='reset']:hover, .disabled[type='submit']:hover, .disabled.button__hollow:hover, .disabled.button__hollow--white:hover, .disabled.button__hollow--expanded:hover {
       cursor: not-allowed; }
 
 .button,
@@ -459,7 +459,7 @@ a {
 
 .button,
 .button__primary, .button__primary--expanded,
-.button__secondary, .button__secondary--expanded, button, [type='button'], [type='reset'], [type='submit'], .button__hollow, .button__hollow--expanded {
+.button__secondary, .button__secondary--expanded, button, [type='button'], [type='reset'], [type='submit'], .button__hollow, .button__hollow--white, .button__hollow--expanded {
   box-shadow: none;
   font-family: "Source Sans Pro", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
   padding: 0.7692307692em 2em 0.7692307692em;
@@ -489,15 +489,6 @@ a {
     background-color: #01515f;
     color: #fff; }
 
-.button__hollow, .button__hollow--expanded {
-  background-color: transparent;
-  border: 1px solid #f9b002;
-  color: #f9b002;
-  font-weight: 300; }
-  .button__hollow:hover, .button__hollow--expanded:hover, .button__hollow:active, .button__hollow--expanded:active, .button__hollow:focus, .button__hollow--expanded:focus {
-    background-color: #f9b002;
-    color: #fff; }
-
 .button__primary--expanded, .button__secondary--expanded, .button__hollow--expanded {
   font-weight: 600;
   padding: 1.6923076923em; }
@@ -505,6 +496,36 @@ a {
 .button__primary--expanded, .button__secondary--expanded, .button__hollow--expanded {
   width: 100%;
   display: block; }
+
+.button__hollow {
+  background-color: transparent;
+  border: 1px solid #f9b002;
+  color: #f9b002;
+  font-weight: 400;
+  letter-spacing: 1.4px; }
+  .button__hollow:hover, .button__hollow:active, .button__hollow:focus {
+    background-color: #f9b002;
+    color: #4d4f53; }
+
+.button__hollow--white {
+  background-color: transparent;
+  border: 1px solid #fff;
+  color: #fff;
+  font-weight: 400;
+  letter-spacing: 1.4px; }
+  .button__hollow--white:hover, .button__hollow--white:active, .button__hollow--white:focus {
+    background-color: #fff;
+    color: #4d4f53; }
+
+.button__hollow--expanded {
+  background-color: transparent;
+  border: 1px solid #f9b002;
+  color: #f9b002;
+  font-weight: 400;
+  letter-spacing: 1.4px; }
+  .button__hollow--expanded:hover, .button__hollow--expanded:active, .button__hollow--expanded:focus {
+    background-color: #f9b002;
+    color: #4d4f53; }
 
 .color-brand {
   color: #8c1515; }

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -2117,20 +2117,26 @@
 
 .masonry-block {
   background-color: #fff; }
-  .masonry-block.is-inverted, .masonry-block.has-background {
+  .masonry-block.is-action, .masonry-block.is-inverted, .masonry-block.has-background {
     background-color: #8c1515;
     color: #fff; }
-    .masonry-block.is-inverted .masonry-block__description,
+    .masonry-block.is-action .masonry-block__description,
+    .masonry-block.is-action .masonry-block__link,
+    .masonry-block.is-action .masonry-block__footer, .masonry-block.is-inverted .masonry-block__description,
     .masonry-block.is-inverted .masonry-block__link,
     .masonry-block.is-inverted .masonry-block__footer, .masonry-block.has-background .masonry-block__description,
     .masonry-block.has-background .masonry-block__link,
     .masonry-block.has-background .masonry-block__footer {
+      position: relative;
       color: #fff; }
-    .masonry-block.is-inverted .masonry-block__link:hover, .masonry-block.is-inverted .masonry-block__link:active, .masonry-block.is-inverted .masonry-block__link:focus, .masonry-block.has-background .masonry-block__link:hover, .masonry-block.has-background .masonry-block__link:active, .masonry-block.has-background .masonry-block__link:focus {
+    .masonry-block.is-action .masonry-block__link:hover, .masonry-block.is-action .masonry-block__link:active, .masonry-block.is-action .masonry-block__link:focus, .masonry-block.is-inverted .masonry-block__link:hover, .masonry-block.is-inverted .masonry-block__link:active, .masonry-block.is-inverted .masonry-block__link:focus, .masonry-block.has-background .masonry-block__link:hover, .masonry-block.has-background .masonry-block__link:active, .masonry-block.has-background .masonry-block__link:focus {
       color: rgba(255, 255, 255, 0.65); }
-    .masonry-block.is-inverted .masonry-block__footer, .masonry-block.has-background .masonry-block__footer {
+    .masonry-block.is-action .masonry-block__footer, .masonry-block.is-inverted .masonry-block__footer, .masonry-block.has-background .masonry-block__footer {
       border-top: 1px solid rgba(255, 255, 255, 0.5); }
-    .masonry-block.is-inverted .masonry-block__arrow:hover svg use, .masonry-block.is-inverted .masonry-block__arrow:active svg use, .masonry-block.is-inverted .masonry-block__arrow:focus svg use,
+    .masonry-block.is-action .masonry-block__arrow:hover svg use, .masonry-block.is-action .masonry-block__arrow:active svg use, .masonry-block.is-action .masonry-block__arrow:focus svg use,
+    .masonry-block.is-action .masonry-block__social-link:hover svg use,
+    .masonry-block.is-action .masonry-block__social-link:active svg use,
+    .masonry-block.is-action .masonry-block__social-link:focus svg use, .masonry-block.is-inverted .masonry-block__arrow:hover svg use, .masonry-block.is-inverted .masonry-block__arrow:active svg use, .masonry-block.is-inverted .masonry-block__arrow:focus svg use,
     .masonry-block.is-inverted .masonry-block__social-link:hover svg use,
     .masonry-block.is-inverted .masonry-block__social-link:active svg use,
     .masonry-block.is-inverted .masonry-block__social-link:focus svg use, .masonry-block.has-background .masonry-block__arrow:hover svg use, .masonry-block.has-background .masonry-block__arrow:active svg use, .masonry-block.has-background .masonry-block__arrow:focus svg use,
@@ -2138,20 +2144,49 @@
     .masonry-block.has-background .masonry-block__social-link:active svg use,
     .masonry-block.has-background .masonry-block__social-link:focus svg use {
       fill: rgba(255, 255, 255, 0.5); }
-    .masonry-block.is-inverted .masonry-block__arrow svg use,
+    .masonry-block.is-action .masonry-block__arrow svg use,
+    .masonry-block.is-action .masonry-block__social-link svg use, .masonry-block.is-inverted .masonry-block__arrow svg use,
     .masonry-block.is-inverted .masonry-block__social-link svg use, .masonry-block.has-background .masonry-block__arrow svg use,
     .masonry-block.has-background .masonry-block__social-link svg use {
       fill: #fff; }
-    .masonry-block.is-inverted .masonry-block__date, .masonry-block.has-background .masonry-block__date {
+    .masonry-block.is-action .masonry-block__date, .masonry-block.is-inverted .masonry-block__date, .masonry-block.has-background .masonry-block__date {
       border-right: 1px solid #fff; }
-    .masonry-block.is-inverted .masonry-block__social-links, .masonry-block.has-background .masonry-block__social-links {
+    .masonry-block.is-action .masonry-block__social-links, .masonry-block.is-inverted .masonry-block__social-links, .masonry-block.has-background .masonry-block__social-links {
       border-right: 1px solid #fff; }
+  .masonry-block.is-action {
+    background-color: #017c92;
+    padding-top: 15px;
+    padding-bottom: 15px; }
+    .masonry-block.is-action .masonry-block__title {
+      margin-bottom: 30px; }
+  @media only screen and (min-width: 768px) {
+    .masonry-block.is-wide .masonry-block__title {
+      font-size: 30px; } }
+  .masonry-block.is-full-width .masonry-block__title {
+    padding-top: 13px; }
+    @media only screen and (min-width: 768px) {
+      .masonry-block.is-full-width .masonry-block__title {
+        font-size: 32px; } }
+  .masonry-block.has-columns .tag-item, .masonry-block.is-full-width .tag-item {
+    border-color: #017c92;
+    color: #017c92; }
+    .masonry-block.has-columns .tag-item:hover, .masonry-block.has-columns .tag-item:active, .masonry-block.has-columns .tag-item:focus, .masonry-block.is-full-width .tag-item:hover, .masonry-block.is-full-width .tag-item:active, .masonry-block.is-full-width .tag-item:focus {
+      background-color: #017c92;
+      color: #fff; }
   .masonry-block .tag-item {
     border-color: #fff;
-    color: #fff; }
+    color: #fff;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale; }
     .masonry-block .tag-item:hover, .masonry-block .tag-item:active, .masonry-block .tag-item:focus {
       background-color: #fff;
       color: #4d4f53; }
+
+.masonry-block__title {
+  font-size: 20px;
+  line-height: 1.4;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale; }
 
 .masonry-block__link {
   color: #4d4f53; }
@@ -2162,7 +2197,8 @@
 .masonry-block__description {
   color: #9c9d9e;
   letter-spacing: .5px;
-  margin-bottom: 4px; }
+  margin-bottom: 4px;
+  line-height: 2em; }
 
 .masonry-block__footer {
   border-top: 1px solid #D8D8D8;
@@ -2184,6 +2220,9 @@
 
 .masonry-block__arrow svg use {
   fill: #8c1515; }
+
+.masonry-block__button {
+  width: 100%; }
 
 .section-masonry-blocks {
   background-color: #dad7cb; }
@@ -3483,7 +3522,8 @@ ul.tabs {
   line-height: 1;
   margin: 0;
   text-transform: uppercase;
-  margin-right: .5em; }
+  margin-right: .5em;
+  margin-bottom: .5em; }
   .tag-item:hover, .tag-item:active, .tag-item:focus {
     background-color: #017c92;
     text-decoration: none;

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -1,47 +1,3 @@
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
-
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
   height: 2px;
@@ -276,50 +232,6 @@
     .block--lockup__site-slogan {
       margin: 0 10px; } }
 
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
-
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
   height: 2px;
@@ -373,50 +285,6 @@
   left: 0; }
   .calendar-block__arrow svg use {
     fill: #8c1515; }
-
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
 
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
@@ -473,50 +341,6 @@
     position: absolute;
     top: 0;
     left: 0; }
-
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
 
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
@@ -588,50 +412,6 @@
     transform: translate(-50%, -50%);
     position: absolute;
     top: 35%; }
-
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
 
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
@@ -927,50 +707,6 @@
     color: #4d4f53;
     text-decoration: none; }
 
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
-
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
   height: 2px;
@@ -1006,50 +742,6 @@
     -ms-transform: translate(-50%, -50%);
     transform: translate(-50%, -50%); }
 
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
-
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
   height: 2px;
@@ -1069,50 +761,6 @@
     color: #fff; }
   .section-expandable-banner .section-header .drop-cap-title__drop-cap {
     opacity: .35; }
-
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
 
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
@@ -1142,50 +790,6 @@
 
 .expandable-card__toggle svg use {
   fill: #8c1515; }
-
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
 
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
@@ -1217,50 +821,6 @@
     display: inline-block;
     vertical-align: middle; }
 
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
-
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
   height: 2px;
@@ -1286,50 +846,6 @@
   letter-spacing: .5px;
   padding-top: 5px;
   margin-bottom: 0; }
-
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
 
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
@@ -1368,50 +884,6 @@
     @media only screen and (min-width: 768px) {
       .filmstrip h6.filmstrip__title {
         color: #222328; } }
-
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
 
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
@@ -1571,50 +1043,6 @@
   .contact-footer .block--lockup__site-slogan {
     margin: 0 0 0 2px; } }
 
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
-
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
   height: 2px;
@@ -1626,50 +1054,6 @@
 #header {
   background: rgba(0, 0, 0, 0.5);
   position: relative; }
-
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
 
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
@@ -1715,50 +1099,6 @@
   .hero-banner__header .cite {
     font-size: 0.7692307692em;
     opacity: 0.8; }
-
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
 
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
@@ -1832,50 +1172,6 @@
   .section-highlight-banner .section-header .drop-cap-title__drop-cap {
     opacity: .35; }
 
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
-
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
   height: 2px;
@@ -1905,50 +1201,6 @@
   margin-left: 5px; }
   .icon-item__arrow svg use {
     fill: #8c1515; }
-
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
 
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
@@ -1987,50 +1239,6 @@
     max-width: 400px;
     margin: 0 auto; }
 
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
-
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
   height: 2px;
@@ -2062,50 +1270,6 @@
   font-size: 12px;
   letter-spacing: .86px;
   text-transform: uppercase; }
-
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
 
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
@@ -2226,50 +1390,6 @@
 
 .section-masonry-blocks {
   background-color: #dad7cb; }
-
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
 
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
@@ -2395,50 +1515,6 @@
       padding-left: 0;
       padding-right: 0; } }
 
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
-
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
   height: 2px;
@@ -2525,50 +1601,6 @@
       .navigation ul ul a:hover, .navigation ul ul a:active, .navigation ul ul a:focus {
         box-shadow: none; }
 
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
-
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
   height: 2px;
@@ -2647,50 +1679,6 @@
 .pager__item--next {
   margin-left: 1.3076923077em; }
 
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
-
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
   height: 2px;
@@ -2720,50 +1708,6 @@
     .postcard .postcard__more use {
       fill: #8c1515; }
 
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
-
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
   height: 2px;
@@ -2778,50 +1722,6 @@
   .player__button:hover use, .player__button:active use, .player__button:focus use {
     stroke: #fff; }
 
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
-
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
   height: 2px;
@@ -2829,50 +1729,6 @@
   content: '';
   display: block;
   z-index: 2; }
-
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
 
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
@@ -2952,50 +1808,6 @@
     .photo-tiles__quote svg use {
       fill: #8c1515; }
 
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
-
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
   height: 2px;
@@ -3066,50 +1878,6 @@
   white-space: nowrap;
   width: 1px; }
 
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
-
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
   height: 2px;
@@ -3154,50 +1922,6 @@
   text-transform: uppercase;
   letter-spacing: .15px; }
 
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
-
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
   height: 2px;
@@ -3212,50 +1936,6 @@
 
 .section-feature-cards p {
   color: #9c9d9e; }
-
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
 
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
@@ -3301,50 +1981,6 @@
   letter-spacing: .15px; }
   .simple-block__more:hover, .simple-block__more:active, .simple-block__more:focus {
     text-decoration: none; }
-
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
 
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;
@@ -3459,50 +2095,6 @@ ul.tabs {
   box-shadow: inset 0 -3px 0 0 #8c1515; }
   .tabs__tab--active a:hover, .tabs__tab--active a:active, .tabs__tab--active a:focus {
     box-shadow: inset 0 -3px 0 0 #8c1515; }
-
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
 
 .section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
   position: absolute;

--- a/css/theme/theme.css
+++ b/css/theme/theme.css
@@ -112,50 +112,6 @@
 .keep-together {
   white-space: nowrap; }
 
-.has-image-overlay {
-  position: relative; }
-  .has-image-overlay::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.35);
-    content: "";
-    display: block;
-    z-index: 1; }
-  .has-image-overlay img {
-    display: block; }
-
-.has-image-gradient {
-  position: relative; }
-  .has-image-gradient::before {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-image: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.3));
-    content: "";
-    display: block; }
-  .has-image-gradient img {
-    display: block; }
-
-.responsive-video-container {
-  overflow: hidden;
-  position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 2em;
-  height: 0; }
-  .responsive-video-container iframe,
-  .responsive-video-container object,
-  .responsive-video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%; }
-
 .block--link-block > .list-item {
   display: block; }
 

--- a/scss/base/_buttons.scss
+++ b/scss/base/_buttons.scss
@@ -93,18 +93,18 @@
 }
 
 .button__hollow {
-  @extend %button__generic;
   @include button__hollow;
+  @extend %button__generic;
 }
 
 .button__hollow--white {
-  @extend %button__generic;
   @include button__hollow(color(white));
+  @extend %button__generic;
 }
 
 .button__hollow--expanded {
-  @extend %button__generic;
   @include button__hollow;
+  @extend %button__generic;
   @extend %button__large;
   @extend %button__expand;
 }

--- a/scss/base/_buttons.scss
+++ b/scss/base/_buttons.scss
@@ -40,21 +40,6 @@
   }
 }
 
-@mixin button__hollow($color: color(emphasis)) {
-  @extend %button__generic;
-
-  background-color: transparent;
-  border: 1px solid $color;
-  color: $color;
-  font-weight: 400;
-  letter-spacing: 1.4px;
-
-  @include on-event {
-    background-color: $color;
-    color: color(text-active);
-  }
-}
-
 %button__large {
   font-weight: 600;
   padding: em(22px);

--- a/scss/base/_buttons.scss
+++ b/scss/base/_buttons.scss
@@ -40,19 +40,18 @@
   }
 }
 
-%button__hollow {
-  $_color: $emphasis-color;
-
+@mixin button__hollow($color: color(emphasis)) {
   @extend %button__generic;
 
   background-color: transparent;
-  border: 1px solid $_color;
-  color: $_color;
-  font-weight: 300;
+  border: 1px solid $color;
+  color: $color;
+  font-weight: 400;
+  letter-spacing: 1.4px;
 
   @include on-event {
-    background-color: $_color;
-    color: color(reverse-text);
+    background-color: $color;
+    color: color(text-active);
   }
 }
 
@@ -95,12 +94,17 @@
 
 .button__hollow {
   @extend %button__generic;
-  @extend %button__hollow;
+  @include button__hollow;
+}
+
+.button__hollow--white {
+  @extend %button__generic;
+  @include button__hollow(color(white));
 }
 
 .button__hollow--expanded {
   @extend %button__generic;
-  @extend %button__hollow;
+  @include button__hollow;
   @extend %button__large;
   @extend %button__expand;
 }

--- a/scss/base/_buttons.scss
+++ b/scss/base/_buttons.scss
@@ -93,18 +93,18 @@
 }
 
 .button__hollow {
-  @include button__hollow;
   @extend %button__generic;
+  @include button__hollow;
 }
 
 .button__hollow--white {
-  @include button__hollow(color(white));
   @extend %button__generic;
+  @include button__hollow(color(white));
 }
 
 .button__hollow--expanded {
-  @include button__hollow;
   @extend %button__generic;
   @extend %button__large;
   @extend %button__expand;
+  @include button__hollow;
 }

--- a/scss/base/base.scss
+++ b/scss/base/base.scss
@@ -17,6 +17,7 @@
 
 // Matson Theme Config.
 @import 'config/config';
+@import 'utilities/mixins/mixins';
 
 //// Decanter base styles.
 @import
@@ -37,6 +38,7 @@
   'fonts',
   'forms',
   'lists',
+  'media',
   'svg',
   'tables',
   'typography';

--- a/scss/components/masonry-block/_masonry-block.scss
+++ b/scss/components/masonry-block/_masonry-block.scss
@@ -12,6 +12,7 @@
 .masonry-block {
   background-color: color(white);
 
+  &.is-action,
   &.is-inverted,
   &.has-background {
     background-color: color(brand);
@@ -20,6 +21,7 @@
     .masonry-block__description,
     .masonry-block__link,
     .masonry-block__footer {
+      position: relative;
       color: color(white);
     }
 
@@ -55,15 +57,65 @@
     }
   }
 
+  &.is-action {
+    background-color: color(action);
+    padding-top: 15px;
+    padding-bottom: 15px;
+
+    .masonry-block__title {
+      margin-bottom: 30px;
+    }
+  }
+
+  &.is-wide {
+    .masonry-block__title {
+      @include grid-media($media-md) {
+        font-size: 30px;
+      }
+    }
+  }
+
+  &.is-full-width {
+    .masonry-block__title {
+      padding-top: 13px;
+
+      @include grid-media($media-md) {
+        font-size: 32px;
+      }
+    }
+  }
+
+  &.has-columns,
+  &.is-full-width {
+    .tag-item {
+      border-color: color(action);
+      color: color(action);
+
+      @include on-event {
+        background-color: color(action);
+        color: color(white);
+      }
+    }
+  }
+
   .tag-item {
     border-color: color(white);
     color: color(white);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 
     @include on-event {
       background-color: color(white);
       color: color(text-active);
     }
   }
+}
+
+.masonry-block__title {
+  font-size: 20px;
+  line-height: 1.4;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 .masonry-block__link {
@@ -79,6 +131,7 @@
   color: color(ash);
   letter-spacing: .5px;
   margin-bottom: 4px;
+  line-height: 2em;
 }
 
 .masonry-block__footer {
@@ -112,6 +165,10 @@
   use {
     fill: color(brand);
   }
+}
+
+.masonry-block__button {
+  width: 100%;
 }
 
 .section-masonry-blocks {

--- a/scss/components/tag-item/_tag-item.scss
+++ b/scss/components/tag-item/_tag-item.scss
@@ -20,6 +20,7 @@
   margin: 0;
   text-transform: uppercase;
   margin-right: .5em;
+  margin-bottom: .5em;
 
   @include on-event {
     background-color: color(action);

--- a/scss/utilities/mixins/_button-hollow.scss
+++ b/scss/utilities/mixins/_button-hollow.scss
@@ -1,0 +1,19 @@
+@charset 'UTF-8';
+
+///
+/// Hollow Button
+///
+@mixin button__hollow($color: color(emphasis)) {
+  @extend %button__generic;
+
+  background-color: transparent;
+  border: 1px solid $color;
+  color: $color;
+  font-weight: 400;
+  letter-spacing: 1.4px;
+
+  @include on-event {
+    background-color: $color;
+    color: color(text-active);
+  }
+}

--- a/scss/utilities/mixins/_media-elements.scss
+++ b/scss/utilities/mixins/_media-elements.scss
@@ -20,10 +20,6 @@
   }
 }
 
-.has-image-overlay {
-  @include image-overlay;
-}
-
 @mixin image-gradient($image-gradient-bg-color: rgba(0, 0, 0, 0.35)) {
   position: relative;
 
@@ -43,10 +39,6 @@
   }
 }
 
-.has-image-gradient {
-  @include image-gradient;
-}
-
 @mixin responsive-video($responsive-video-aspect-ratio: 56.25%, $responsive-video-padding-top: 2em) {
   overflow: hidden;
   position: relative;
@@ -63,8 +55,4 @@
     width: 100%;
     height: 100%;
   }
-}
-
-.responsive-video-container {
-  @include responsive-video;
 }

--- a/scss/utilities/mixins/mixins.scss
+++ b/scss/utilities/mixins/mixins.scss
@@ -5,7 +5,8 @@
 
 @import
   "fade-type",
-  'hero-banner-node',
+  "hero-banner-node",
+  "button-hollow",
   "media-elements",
   "text-decoration",
   "center-transform";


### PR DESCRIPTION
READY FOR REVIEW

# Summary
- Adding multi column masonry cards variants.
1. has-columns. Adds columns to masonry card. Uses background image url to ensure photo fits edge to edge.
2. is-full-width. Does everything has-columns does plus expands the masonry card to fill all columns.
3. has-image-right. Sub class of either has-columns or .is-full-width. Aligns image to the right.
3. is-column-width. Default class added to all masonry cards if not of the above variants defined.
4. action. Field is used for subscribe masonry CTA. Inverts color scheme, background blue and adds button.

# Needed By next sprint

# Steps to Test

1. Download complimentary branch in Stanford Components EARTH-282-masonry-postcards
2. Preview molecules/masonry-cards. See full width cards left and right. See action card with subscribe button. Scroll to bottom to see has columns cards left and right.
3. Preview organisms/masonry-cards. Test responsiveness.

# Associated Issues and/or People
- JIRA ticket EARTH-282
- See complimentary branch in Stanford Components EARTH-282-masonry-postcards
- Documented variant classes in molecule/masonry-card twig 
- @sherakama 

