### PR TITLE
EARTH-294: Fixes to z-index of image for icon-block.

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -311,10 +311,13 @@
       transition: all .3s ease; }
       .callout-block:hover, .callout-block:active, .callout-block:focus {
         margin-top: -1rem; } }
-  .callout-block .callout-block__title a {
-    color: #8c1515; }
-    .callout-block .callout-block__title a:hover, .callout-block .callout-block__title a:active, .callout-block .callout-block__title a:focus {
-      text-decoration: none; }
+  .callout-block .callout-block__title {
+    z-index: 1;
+    position: relative; }
+    .callout-block .callout-block__title a {
+      color: #8c1515; }
+      .callout-block .callout-block__title a:hover, .callout-block .callout-block__title a:active, .callout-block .callout-block__title a:focus {
+        text-decoration: none; }
   .callout-block .callout-block__intro {
     color: #9c9d9e;
     font-size: 0.9230769231em;
@@ -339,6 +342,7 @@
       fill: #8c1515; }
   .callout-block .callout-block__icon {
     position: absolute;
+    z-index: 0;
     top: 0;
     left: 0; }
 

--- a/scss/components/callout-block/_callout-block.scss
+++ b/scss/components/callout-block/_callout-block.scss
@@ -37,6 +37,8 @@
   }
 
   .callout-block__title {
+    z-index: 1;
+    position: relative;
     a {
       color: color(brand);
 
@@ -86,6 +88,7 @@
 
   .callout-block__icon {
     position: absolute;
+    z-index: 0;
     top: 0;
     left: 0;
   }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Drops the image behind the text on the callout block icon.

# Needed By (Date)
- End of July

# Criticality
- Low

# Steps to Test

1. Check out this branch
2. Clear caches
3. Create or review and existing callout blocks paragraph type

# Associated Issues and/or People
-EARTH-294

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)