### PR TITLE
EARTH-167: Section Header Variations

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -1990,6 +1990,17 @@
   display: block;
   z-index: 2; }
 
+.simple-columns {
+  color: #9c9d9e; }
+
+.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+  position: absolute;
+  height: 2px;
+  width: 20px;
+  content: '';
+  display: block;
+  z-index: 2; }
+
 .spotlight-card {
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1); }
 

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -1,4 +1,4 @@
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -232,7 +232,7 @@
     .block--lockup__site-slogan {
       margin: 0 10px; } }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -286,7 +286,7 @@
   .calendar-block__arrow svg use {
     fill: #8c1515; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -342,7 +342,7 @@
     top: 0;
     left: 0; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -413,7 +413,7 @@
     position: absolute;
     top: 35%; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -707,7 +707,7 @@
     color: #4d4f53;
     text-decoration: none; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -742,7 +742,7 @@
     -ms-transform: translate(-50%, -50%);
     transform: translate(-50%, -50%); }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -762,7 +762,7 @@
   .section-expandable-banner .section-header .drop-cap-title__drop-cap {
     opacity: .35; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -791,7 +791,7 @@
 .expandable-card__toggle svg use {
   fill: #8c1515; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -821,7 +821,7 @@
     display: inline-block;
     vertical-align: middle; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -847,7 +847,7 @@
   padding-top: 5px;
   margin-bottom: 0; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -885,7 +885,7 @@
       .filmstrip h6.filmstrip__title {
         color: #222328; } }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1043,7 +1043,7 @@
   .contact-footer .block--lockup__site-slogan {
     margin: 0 0 0 2px; } }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1055,7 +1055,7 @@
   background: rgba(0, 0, 0, 0.5);
   position: relative; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1100,7 +1100,7 @@
     font-size: 0.7692307692em;
     opacity: 0.8; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1172,7 +1172,7 @@
   .section-highlight-banner .section-header .drop-cap-title__drop-cap {
     opacity: .35; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1202,7 +1202,7 @@
   .icon-item__arrow svg use {
     fill: #8c1515; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1239,7 +1239,7 @@
     max-width: 400px;
     margin: 0 auto; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1271,7 +1271,7 @@
   letter-spacing: .86px;
   text-transform: uppercase; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1391,7 +1391,7 @@
 .section-masonry-blocks {
   background-color: #dad7cb; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1515,7 +1515,7 @@
       padding-left: 0;
       padding-right: 0; } }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1601,7 +1601,7 @@
       .navigation ul ul a:hover, .navigation ul ul a:active, .navigation ul ul a:focus {
         box-shadow: none; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1679,7 +1679,7 @@
 .pager__item--next {
   margin-left: 1.3076923077em; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1708,7 +1708,7 @@
     .postcard .postcard__more use {
       fill: #8c1515; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1722,7 +1722,7 @@
   .player__button:hover use, .player__button:active use, .player__button:focus use {
     stroke: #fff; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1730,7 +1730,7 @@
   display: block;
   z-index: 2; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1808,7 +1808,7 @@
     .photo-tiles__quote svg use {
       fill: #8c1515; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1878,7 +1878,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1888,30 +1888,30 @@
 
 .section-header {
   color: #4d4f53; }
-  .section-header h2.has-dash--under {
+  .section-header h2.has-dash-under {
     margin-bottom: 1.25em; }
-    .section-header h2.has-dash--under::after {
+    .section-header h2.has-dash-under::after {
       background-color: #8c1515;
       bottom: -.5em;
       left: 50%;
       transform: translateX(-50%); }
-  .section-header h2.has-dash--left {
+  .section-header h2.has-dash-left {
     margin-bottom: 1.25em; }
     @media only screen and (min-width: 768px) {
-      .section-header h2.has-dash--left {
+      .section-header h2.has-dash-left {
         margin-bottom: .75em; } }
-    .section-header h2.has-dash--left::after {
+    .section-header h2.has-dash-left::after {
       bottom: -.5em;
       left: 50%;
       transform: translateX(-50%);
       background-color: #8c1515; }
       @media only screen and (min-width: 768px) {
-        .section-header h2.has-dash--left::after {
+        .section-header h2.has-dash-left::after {
           bottom: auto;
           top: .625em;
           left: -.9em;
           transform: none; } }
-  .section-header h2.has-dash--emphasis::after {
+  .section-header h2.has-dash-emphasis::after {
     background-color: #f9b002; }
   .section-header p {
     line-height: 1.6923076923em;
@@ -1922,7 +1922,7 @@
   text-transform: uppercase;
   letter-spacing: .15px; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1937,7 +1937,7 @@
 .section-feature-cards p {
   color: #9c9d9e; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1982,7 +1982,7 @@
   .simple-block__more:hover, .simple-block__more:active, .simple-block__more:focus {
     text-decoration: none; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1993,7 +1993,7 @@
 .simple-columns {
   color: #9c9d9e; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -2019,7 +2019,7 @@
     letter-spacing: .9px;
     text-transform: uppercase; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -2133,7 +2133,7 @@ ul.tabs {
   .tabs__tab--active a:hover, .tabs__tab--active a:active, .tabs__tab--active a:focus {
     box-shadow: inset 0 -3px 0 0 #8c1515; }
 
-.section-header h2.has-dash--under::after, .section-header h2.has-dash--left::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
   width: 20px;

--- a/scss/components/components.scss
+++ b/scss/components/components.scss
@@ -60,6 +60,7 @@
   "section-header/section-header",
   "section-feature-cards/section-feature-cards",
   "simple-block/simple-block",
+  "simple-columns/simple-columns",
   "spotlight-card/spotlight-card",
   "sticky-footer/sticky-footer",
   "tabs/tabs",

--- a/scss/components/section-header/_section-header.scss
+++ b/scss/components/section-header/_section-header.scss
@@ -13,15 +13,15 @@
   color: color(text-active);
 
   h2 {
-    &.has-dash--under {
+    &.has-dash-under {
       @include dash-under($dash-color: brand);
     }
 
-    &.has-dash--left {
+    &.has-dash-left {
       @include dash-left($dash-color: brand);
     }
 
-    &.has-dash--emphasis::after {
+    &.has-dash-emphasis::after {
       background-color: color(emphasis);
     }
   }

--- a/scss/components/simple-columns/_simple-columns.scss
+++ b/scss/components/simple-columns/_simple-columns.scss
@@ -1,0 +1,15 @@
+@charset 'UTF-8';
+
+// My Config.
+@import "config/config";
+
+// Decanter config.
+@import "decanter/core/utilities/decanter-utilities";
+
+// Grab our mixins.
+@import "utilities/utilities";
+
+.simple-columns {
+  color: color(ash);
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adds new Matson theme customizations for section header variations (EARTH 167). Includes a new simple columns molecule component.

Note: Code change in this PR add the Section Header variant for columns only. The centered section header variant already exists as part of /patterns/section_header. See "is_centered" and "centered_container" variant.

# Needed By (Date)
- Next Sprint (7/21)

# Steps to Test

1. View the new Section Header Columns organism here: /patterns/section_header_columns
2. View the pre-existing Section Header molecule here: /patterns/section_header
3. View the new Simple Columns molecule here: /patterns/simple_columns

# Affected versions or modules
- Does this PR impact any particular module, version, or pull request?

# Associated Issues and/or People
- JIRA ticket: EARTH-167
- Other PRs: [Stanford Components PR #62](https://github.com/SU-SWS/stanford_components/pull/62)
