### PR TITLE
EARTH-382 address borked drop cap

### DIFF
--- a/css/base/base.css
+++ b/css/base/base.css
@@ -815,7 +815,7 @@ body {
   @media only screen and (max-width: 767px) {
     body {
       font-size: 1.3em; } }
-  @media only screen and (min-width: 1200px) {
+  @media only screen and (min-width: 1500px) {
     body {
       font-size: 1.3em; } }
   @media only print {

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -726,6 +726,9 @@
 .drop-cap-title__name {
   position: relative;
   z-index: 2; }
+  .drop-cap-title__name > div {
+    position: relative;
+    z-index: 3; }
 
 .drop-cap-title__drop-cap {
   position: absolute;

--- a/scss/components/drop-cap/_drop-cap.scss
+++ b/scss/components/drop-cap/_drop-cap.scss
@@ -17,6 +17,11 @@
 .drop-cap-title__name {
   position: relative;
   z-index: 2;
+
+  > div {
+    position: relative;
+    z-index: 3;
+  }
 }
 
 .drop-cap-title__drop-cap {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Addresses the broken drop caps for the expandable cards and postcard titles paragraph types

# Needed By (Date)
- N/A

# Urgency
- No

# Steps to Test
- Pull this branch and check examples page

# Affected Projects or Products
- Earth, Matson theme

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/EARTH-382


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)

# Notes/Questions
Can't identify why the media query is changing from 1200px to 1500px (base.css) Was a mixin changed since the last time the drop cap file was saved?