### PR TITLE
EARTH-76 upped stanford login size and tweaks related styles

### DIFF
--- a/css/base/base.css
+++ b/css/base/base.css
@@ -815,7 +815,7 @@ body {
   @media only screen and (max-width: 767px) {
     body {
       font-size: 1.3em; } }
-  @media only screen and (min-width: 1200px) {
+  @media only screen and (min-width: 1500px) {
     body {
       font-size: 1.3em; } }
   @media only print {

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -117,8 +117,9 @@
           width: 153px; } }
   .brand-bar .brand-bar__login {
     float: right;
-    font-size: 0.9230769231em;
-    font-weight: 600; }
+    font-size: 1.0769230769em;
+    font-weight: 400;
+    letter-spacing: 0.1076923077em; }
 
 .block--lockup {
   background-size: 160px 140px;

--- a/scss/components/brand-bar/_brand-bar.scss
+++ b/scss/components/brand-bar/_brand-bar.scss
@@ -20,7 +20,7 @@
   //  xl: (columns: 12, grid-media: $media-xl,          v-space: 10px, max-width: true,  grid-collapse: false),
   //  print: (columns: 12, grid-media: $media-print,    v-space: 10px, max-width: false, grid-collapse: false),
   //) !default;
-  
+
   @include responsive-container($default-container);
   height: 40px;
   max-height: 40px;
@@ -34,6 +34,7 @@
     &:first-child {
       display: inline-block;
       width: 123px;
+
       @include grid-media($media-sm) {
         width: 153px;
       }

--- a/scss/components/brand-bar/_brand-bar.scss
+++ b/scss/components/brand-bar/_brand-bar.scss
@@ -20,7 +20,7 @@
   //  xl: (columns: 12, grid-media: $media-xl,          v-space: 10px, max-width: true,  grid-collapse: false),
   //  print: (columns: 12, grid-media: $media-print,    v-space: 10px, max-width: false, grid-collapse: false),
   //) !default;
-
+  
   @include responsive-container($default-container);
   height: 40px;
   max-height: 40px;
@@ -34,7 +34,6 @@
     &:first-child {
       display: inline-block;
       width: 123px;
-
       @include grid-media($media-sm) {
         width: 153px;
       }
@@ -43,8 +42,9 @@
 
   .brand-bar__login {
     float: right;
-    font-size: em(12px);
-    font-weight: 600;
+    font-size: em(14px);
+    font-weight: 400;
+    letter-spacing: em(1.4px);
   }
 
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Increase the size of the "Login with your SUNetID" link in the global header; update related styles (font-weight and letter-spacing)

# Needed By (Date)
- N/A

# Urgency
- No

# Steps to Test
- Pull this branch and check the "Login with your SUNetID" link in the global header

# Affected Projects or Products
- Earth, Matson theme

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/EARTH-76


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)

# Notes/Questions
- for my own edification, where would I find where the stanford-brand-bar mixin is being defined? I checked in (what I thought to be) the most logical places without any luck. Appreciate the tip!
- 1200px to 1500px (in base.css) happening here, too. Same question as PR 62.