### PR TITLE
EARTH-174 drop caps cannot be selected

### DIFF
--- a/css/base/base.css
+++ b/css/base/base.css
@@ -815,7 +815,7 @@ body {
   @media only screen and (max-width: 767px) {
     body {
       font-size: 1.3em; } }
-  @media only screen and (min-width: 1200px) {
+  @media only screen and (min-width: 1500px) {
     body {
       font-size: 1.3em; } }
   @media only print {

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -733,7 +733,11 @@
   left: -.225em;
   font-size: 80px;
   color: #eeeeee;
-  z-index: 1; }
+  z-index: 1;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none; }
   .drop-cap-title__drop-cap.drop-cap--is-centered {
     position: absolute;
     top: 50%;

--- a/scss/components/drop-cap/_drop-cap.scss
+++ b/scss/components/drop-cap/_drop-cap.scss
@@ -26,6 +26,10 @@
   font-size: 80px;
   color: darken(color(dust), 5%);
   z-index: 1;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 
   &.drop-cap--is-centered {
     @include center-transform;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Remove the ability for drop caps to be selectable (via copy paste, etc.)

# Needed By (Date)
- N/A

# Urgency
- No

# Steps to Test
- Pull this branch and check any paragraph type with drop caps

# Affected Projects or Products
- Earth, Matson theme

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/EARTH-174


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)

# Notes/Questions
- the z-index fix (PR 62) will largely address this issue, but this would be useful as a fallback
- 1200px to 1500px (in base.css) happening here, too. Same question as PR 62 and 63.