### PR TITLE
EARTH-384 matched postcard text box style to comp

### DIFF
--- a/css/base/base.css
+++ b/css/base/base.css
@@ -815,7 +815,7 @@ body {
   @media only screen and (max-width: 767px) {
     body {
       font-size: 1.3em; } }
-  @media only screen and (min-width: 1200px) {
+  @media only screen and (min-width: 1500px) {
     body {
       font-size: 1.3em; } }
   @media only print {

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -1746,8 +1746,12 @@
 
 .postcard {
   background-color: #FBFBFB; }
+  .postcard .postcard__content-inner {
+    padding: 25px 0;
+    background-color: transparent; }
   .postcard .postcard__content-text {
     color: #9c9d9e;
+    background-color: #fff;
     line-height: 2em;
     text-align: center; }
   .postcard .postcard__title {

--- a/scss/components/postcard/_postcard.scss
+++ b/scss/components/postcard/_postcard.scss
@@ -13,8 +13,14 @@
 .postcard {
   background-color: color(dust);
 
+  .postcard__content-inner {
+    padding: 25px 0;
+    background-color: transparent;
+  }
+
   .postcard__content-text {
     color: color(ash);
+    background-color: color(white);
     line-height: 2em;
     text-align: center;
   }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Matched the text box style for the Postcard paragraph type to the comp (overlaying over background image)

# Needed By (Date)
- N/A

# Urgency
- No

# Steps to Test
- Pull this branch and ensure styles are passed through to the Postcard paragraph type

# Affected Projects or Products
- Earth, Matson theme

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/EARTH-384

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)

# Notes/Questions
- the z-index fix (PR 62) will largely address this issue, but this would be useful as a fallback
- 1200px to 1500px (in base.css) happening here, too. Same question as other PRs