### PR TITLE
EARTH-404: Template updates

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -1123,6 +1123,51 @@
     font-size: 0.7692307692em;
     opacity: 0.8; }
 
+.hero-banner__footer {
+  text-align: right; }
+  @media only screen and (max-width: 575px) {
+    .hero-banner__footer {
+      padding: 1em calc(((50% /12) * 0) + 15px); }
+      .hero-banner__footer::after {
+        clear: both;
+        content: "";
+        display: block; } }
+  @media only screen and (min-width: 576px) and (max-width: 767px) {
+    .hero-banner__footer {
+      padding: 1em calc(((50% /12) * 0) + 15px); }
+      .hero-banner__footer::after {
+        clear: both;
+        content: "";
+        display: block; } }
+  @media only screen and (min-width: 768px) and (max-width: 1023px) {
+    .hero-banner__footer {
+      padding: 1em calc(((50% /12) * 0) + 30px); }
+      .hero-banner__footer::after {
+        clear: both;
+        content: "";
+        display: block; } }
+  @media only screen and (min-width: 1024px) and (max-width: 1499px) {
+    .hero-banner__footer {
+      padding: 1em calc(((50% /12) * 0) + 30px); }
+      .hero-banner__footer::after {
+        clear: both;
+        content: "";
+        display: block; } }
+  @media only screen and (min-width: 1500px) {
+    .hero-banner__footer {
+      padding: 1em calc(50% - (750px - 60px)); }
+      .hero-banner__footer::after {
+        clear: both;
+        content: "";
+        display: block; } }
+  @media only print {
+    .hero-banner__footer {
+      padding: 1em calc(((50% /12) * 0) + 0.25in); }
+      .hero-banner__footer::after {
+        clear: both;
+        content: "";
+        display: block; } }
+
 .section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;

--- a/css/layout/stanford-news.css
+++ b/css/layout/stanford-news.css
@@ -15,6 +15,9 @@
     .block--local-tasks ul.tabs li {
       display: block; }
 
+.block--field-s-news-sub-title {
+  max-width: 75%; }
+
 @media only screen and (min-width: 768px) {
   .block--field-earth-matters-topic {
     float: right; } }

--- a/css/layout/stanford-news.css
+++ b/css/layout/stanford-news.css
@@ -15,8 +15,4 @@
     .block--local-tasks ul.tabs li {
       display: block; }
 
-.block-region-first .block-ctools-block {
-  column-count: 2;
-  column-gap: 20px; }
-
 /*# sourceMappingURL=stanford-news.css.map */

--- a/css/layout/stanford-news.css
+++ b/css/layout/stanford-news.css
@@ -15,4 +15,27 @@
     .block--local-tasks ul.tabs li {
       display: block; }
 
+@media only screen and (min-width: 768px) {
+  .block--field-earth-matters-topic {
+    float: right; } }
+
+.block--field-earth-matters-topic .field-label {
+  text-decoration: underline;
+  display: inline-block; }
+  .block--field-earth-matters-topic .field-label:after {
+    content: ": "; }
+
+.block--field-earth-matters-topic .field--field-earth-matters-topic {
+  display: inline-block;
+  border: 1px solid;
+  padding: 5px 10px; }
+
+.block--field-s-news-category .field--field-s-news-category {
+  display: inline-block;
+  text-transform: uppercase;
+  padding: 0 10px 0 0; }
+
+.field--body {
+  padding: 20px 80px; }
+
 /*# sourceMappingURL=stanford-news.css.map */

--- a/css/layout/stanford-news.css
+++ b/css/layout/stanford-news.css
@@ -15,8 +15,9 @@
     .block--local-tasks ul.tabs li {
       display: block; }
 
-.block--field-s-news-sub-title {
-  max-width: 75%; }
+@media only screen and (min-width: 576px) {
+  .block--field-s-news-sub-title {
+    max-width: 75%; } }
 
 @media only screen and (min-width: 768px) {
   .block--field-earth-matters-topic {
@@ -38,7 +39,8 @@
   text-transform: uppercase;
   padding: 0 10px 0 0; }
 
-.field--body {
-  padding: 20px 80px; }
+@media only screen and (min-width: 576px) {
+  .field--body {
+    padding: 20px 80px; } }
 
 /*# sourceMappingURL=stanford-news.css.map */

--- a/scss/components/hero-banner/_hero-banner.scss
+++ b/scss/components/hero-banner/_hero-banner.scss
@@ -71,3 +71,8 @@ $hero-max-width-lg: 1500px;
     opacity: 0.8;
   }
 }
+
+.hero-banner__footer {
+  @include responsive-container($default-container);
+  text-align: right;
+}

--- a/scss/layout/stanford-news.scss
+++ b/scss/layout/stanford-news.scss
@@ -10,7 +10,9 @@
 
 // Subtitle field.
 .block--field-s-news-sub-title {
-  max-width: 75%;
+  @include grid-media($media-sm) {
+    max-width: 75%;
+  }
 }
 
 // Earth matters field.
@@ -48,5 +50,7 @@
 
 // Body field.
 .field--body {
-  padding: 20px 80px;
+  @include grid-media($media-sm) {
+    padding: 20px 80px;
+  }
 }

--- a/scss/layout/stanford-news.scss
+++ b/scss/layout/stanford-news.scss
@@ -7,3 +7,41 @@
 
 // Pop out the tabs from the dom flow so they hover over.
 @include hero-banner-node;
+
+// Earth matters field.
+.block--field-earth-matters-topic {
+
+  @include grid-media($media-md) {
+    float: right;
+  }
+
+  .field-label {
+    &:after {
+      content: ": ";
+    }
+    color: color('highlight');
+    text-decoration: underline;
+    display: inline-block;
+  }
+
+  .field--field-earth-matters-topic {
+    display: inline-block;
+    border: 1px solid color('highlight');
+    padding: 5px 10px;
+  }
+
+}
+
+// Category Block.
+.block--field-s-news-category {
+  .field--field-s-news-category {
+    display: inline-block;
+    text-transform: uppercase;
+    padding: 0 10px 0 0;
+  }
+}
+
+// Body field.
+.field--body {
+  padding: 20px 80px;
+}

--- a/scss/layout/stanford-news.scss
+++ b/scss/layout/stanford-news.scss
@@ -7,11 +7,3 @@
 
 // Pop out the tabs from the dom flow so they hover over.
 @include hero-banner-node;
-
-// Set the intro text to be two columns.
-.block-region-first {
-  .block-ctools-block {
-    column-count: 2;
-    column-gap: 20px;
-  }
-}

--- a/scss/layout/stanford-news.scss
+++ b/scss/layout/stanford-news.scss
@@ -24,7 +24,7 @@
     color: color('highlight');
     text-decoration: underline;
     display: inline-block;
-    
+
     &::after {
       content: ": ";
     }

--- a/scss/layout/stanford-news.scss
+++ b/scss/layout/stanford-news.scss
@@ -21,12 +21,13 @@
   }
 
   .field-label {
-    &:after {
-      content: ": ";
-    }
     color: color('highlight');
     text-decoration: underline;
     display: inline-block;
+    
+    &::after {
+      content: ": ";
+    }
   }
 
   .field--field-earth-matters-topic {

--- a/scss/layout/stanford-news.scss
+++ b/scss/layout/stanford-news.scss
@@ -8,6 +8,11 @@
 // Pop out the tabs from the dom flow so they hover over.
 @include hero-banner-node;
 
+// Subtitle field.
+.block--field-s-news-sub-title {
+  max-width: 75%;
+}
+
 // Earth matters field.
 .block--field-earth-matters-topic {
 

--- a/templates/stanford_news/block--entity-field--node--field-earth-matters-topic.html.twig
+++ b/templates/stanford_news/block--entity-field--node--field-earth-matters-topic.html.twig
@@ -1,0 +1,37 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+<div{{ attributes.addClass("field-earth-matters-topic") }}>
+  {{ title_prefix }}
+  {% if label %}
+    <h2{{ title_attributes }}>{{ label }}</h2>
+  {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</div>

--- a/templates/stanford_news/block--entity-field--node--field-earth-matters-topic.html.twig
+++ b/templates/stanford_news/block--entity-field--node--field-earth-matters-topic.html.twig
@@ -25,7 +25,7 @@
  * @see template_preprocess_block()
  */
 #}
-<div{{ attributes.addClass("field-earth-matters-topic") }}>
+<div{{ attributes.addClass("block--field-earth-matters-topic") }}>
   {{ title_prefix }}
   {% if label %}
     <h2{{ title_attributes }}>{{ label }}</h2>

--- a/templates/stanford_news/block--entity-field--node--field-s-news-author.html.twig
+++ b/templates/stanford_news/block--entity-field--node--field-s-news-author.html.twig
@@ -28,7 +28,7 @@
 <div{{ attributes.addClass("block--field-s-news-author") }}>
   {{ title_prefix }}
   {% if label %}
-    <h2{{ title_attributes }}>{{ label }}</h2>
+    <span{{ title_attributes }}>{{ label }} </span>
   {% endif %}
   {{ title_suffix }}
   {% block content %}

--- a/templates/stanford_news/block--entity-field--node--field-s-news-author.html.twig
+++ b/templates/stanford_news/block--entity-field--node--field-s-news-author.html.twig
@@ -25,7 +25,7 @@
  * @see template_preprocess_block()
  */
 #}
-<div{{ attributes.addClass("field-s-news-author") }}>
+<div{{ attributes.addClass("block--field-s-news-author") }}>
   {{ title_prefix }}
   {% if label %}
     <h2{{ title_attributes }}>{{ label }}</h2>

--- a/templates/stanford_news/block--entity-field--node--field-s-news-author.html.twig
+++ b/templates/stanford_news/block--entity-field--node--field-s-news-author.html.twig
@@ -1,0 +1,37 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+<div{{ attributes.addClass("field-s-news-author") }}>
+  {{ title_prefix }}
+  {% if label %}
+    <h2{{ title_attributes }}>{{ label }}</h2>
+  {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</div>

--- a/templates/stanford_news/block--entity-field--node--field-s-news-category.html.twig
+++ b/templates/stanford_news/block--entity-field--node--field-s-news-category.html.twig
@@ -1,0 +1,37 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+<div{{ attributes.addClass("field-s-news-category") }}>
+  {{ title_prefix }}
+  {% if label %}
+    <h2{{ title_attributes }}>{{ label }}</h2>
+  {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</div>

--- a/templates/stanford_news/block--entity-field--node--field-s-news-category.html.twig
+++ b/templates/stanford_news/block--entity-field--node--field-s-news-category.html.twig
@@ -25,7 +25,7 @@
  * @see template_preprocess_block()
  */
 #}
-<div{{ attributes.addClass("field-s-news-category") }}>
+<div{{ attributes.addClass("block--field-s-news-category") }}>
   {{ title_prefix }}
   {% if label %}
     <h2{{ title_attributes }}>{{ label }}</h2>

--- a/templates/stanford_news/block--entity-field--node--field-s-news-date.html.twig
+++ b/templates/stanford_news/block--entity-field--node--field-s-news-date.html.twig
@@ -25,7 +25,7 @@
  * @see template_preprocess_block()
  */
 #}
-<div{{ attributes.addClass("field-s-news-date") }}>
+<div{{ attributes.addClass("block--field-s-news-date") }}>
   {{ title_prefix }}
   {% if label %}
     <h2{{ title_attributes }}>{{ label }}</h2>

--- a/templates/stanford_news/block--entity-field--node--field-s-news-date.html.twig
+++ b/templates/stanford_news/block--entity-field--node--field-s-news-date.html.twig
@@ -1,0 +1,37 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+<div{{ attributes.addClass("field-s-news-date") }}>
+  {{ title_prefix }}
+  {% if label %}
+    <h2{{ title_attributes }}>{{ label }}</h2>
+  {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</div>

--- a/templates/stanford_news/block--entity-field--node--field-s-news-source.html.twig
+++ b/templates/stanford_news/block--entity-field--node--field-s-news-source.html.twig
@@ -25,7 +25,7 @@
  * @see template_preprocess_block()
  */
 #}
-<div{{ attributes.addClass("field-s-news-source") }}>
+<div{{ attributes.addClass("block--field-s-news-source") }}>
   {{ title_prefix }}
   {% if label %}
     <h2{{ title_attributes }}>{{ label }}</h2>

--- a/templates/stanford_news/block--entity-field--node--field-s-news-source.html.twig
+++ b/templates/stanford_news/block--entity-field--node--field-s-news-source.html.twig
@@ -1,0 +1,37 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+<div{{ attributes.addClass("field-s-news-source") }}>
+  {{ title_prefix }}
+  {% if label %}
+    <h2{{ title_attributes }}>{{ label }}</h2>
+  {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</div>

--- a/templates/stanford_news/block--entity-field--node--field-s-news-sub-title.html.twig
+++ b/templates/stanford_news/block--entity-field--node--field-s-news-sub-title.html.twig
@@ -1,0 +1,37 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+<div{{ attributes.addClass("field-s-news-sub-title") }}>
+  {{ title_prefix }}
+  {% if label %}
+    <h2{{ title_attributes }}>{{ label }}</h2>
+  {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</div>

--- a/templates/stanford_news/block--entity-field--node--field-s-news-sub-title.html.twig
+++ b/templates/stanford_news/block--entity-field--node--field-s-news-sub-title.html.twig
@@ -26,12 +26,7 @@
  */
 #}
 <div{{ attributes.addClass("block--field-s-news-sub-title") }}>
-  {{ title_prefix }}
-  {% if label %}
-    <h2{{ title_attributes }}>{{ label }}</h2>
-  {% endif %}
-  {{ title_suffix }}
   {% block content %}
-    {{ content }}
+    <h2>{{ content|render|striptags|trim }}</h2>
   {% endblock %}
 </div>

--- a/templates/stanford_news/block--entity-field--node--field-s-news-sub-title.html.twig
+++ b/templates/stanford_news/block--entity-field--node--field-s-news-sub-title.html.twig
@@ -25,7 +25,7 @@
  * @see template_preprocess_block()
  */
 #}
-<div{{ attributes.addClass("field-s-news-sub-title") }}>
+<div{{ attributes.addClass("block--field-s-news-sub-title") }}>
   {{ title_prefix }}
   {% if label %}
     <h2{{ title_attributes }}>{{ label }}</h2>

--- a/templates/stanford_news/field--node--body--stanford-news.html.twig
+++ b/templates/stanford_news/field--node--body--stanford-news.html.twig
@@ -1,0 +1,65 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
+
+{% if label_hidden %}
+  {% if multiple %}
+    <div{{ attributes }}>
+      {% for item in items %}
+        <div{{ item.attributes.addClass("field--body") }}>{{ item.content }}</div>
+      {% endfor %}
+    </div>
+  {% else %}
+    {% for item in items %}
+      <div{{ attributes.addClass("field--body") }}>{{ item.content }}</div>
+    {% endfor %}
+  {% endif %}
+{% else %}
+  <div{{ attributes }}>
+    <div{{ title_attributes }}>{{ label }}</div>
+    {% if multiple %}
+      <div>
+    {% endif %}
+    {% for item in items %}
+      <div{{ item.attributes.addClass("field--body") }}>{{ item.content }}</div>
+    {% endfor %}
+    {% if multiple %}
+      </div>
+    {% endif %}
+  </div>
+{% endif %}

--- a/templates/stanford_news/field--node--field-earth-matters-topic.html.twig
+++ b/templates/stanford_news/field--node--field-earth-matters-topic.html.twig
@@ -1,0 +1,65 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
+
+{% if label_hidden %}
+  {% if multiple %}
+    <div{{ attributes }}>
+      {% for item in items %}
+        <div{{ item.attributes.addClass("field--field-earth-matters-topic") }}>{{ item.content }}</div>
+      {% endfor %}
+    </div>
+  {% else %}
+    {% for item in items %}
+      <div{{ attributes.addClass("field--field-earth-matters-topic") }}>{{ item.content }}</div>
+    {% endfor %}
+  {% endif %}
+{% else %}
+  <div{{ attributes }}>
+    <div{{ title_attributes }}>{{ label }}</div>
+    {% if multiple %}
+      <div>
+    {% endif %}
+    {% for item in items %}
+      <div{{ item.attributes.addClass("field--field-earth-matters-topic") }}>{{ item.content }}</div>
+    {% endfor %}
+    {% if multiple %}
+      </div>
+    {% endif %}
+  </div>
+{% endif %}

--- a/templates/stanford_news/field--node--field-earth-matters-topic.html.twig
+++ b/templates/stanford_news/field--node--field-earth-matters-topic.html.twig
@@ -51,15 +51,13 @@
   {% endif %}
 {% else %}
   <div{{ attributes }}>
-    <div{{ title_attributes }}>{{ label }}</div>
+    <span{{ title_attributes.addClass('field-label') }}>{{ label }}</span>
     {% if multiple %}
-      <div>
     {% endif %}
     {% for item in items %}
       <div{{ item.attributes.addClass("field--field-earth-matters-topic") }}>{{ item.content }}</div>
     {% endfor %}
     {% if multiple %}
-      </div>
     {% endif %}
   </div>
 {% endif %}

--- a/templates/stanford_news/field--node--field-s-news-author.html.twig
+++ b/templates/stanford_news/field--node--field-s-news-author.html.twig
@@ -1,0 +1,65 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
+
+{% if label_hidden %}
+  {% if multiple %}
+    <div{{ attributes }}>
+      {% for item in items %}
+        <div{{ item.attributes.addClass("field--field-s-news-author") }}>{{ item.content }}</div>
+      {% endfor %}
+    </div>
+  {% else %}
+    {% for item in items %}
+      <div{{ attributes.addClass("field--field-s-news-author") }}>{{ item.content }}</div>
+    {% endfor %}
+  {% endif %}
+{% else %}
+  <div{{ attributes }}>
+    <div{{ title_attributes }}>{{ label }}</div>
+    {% if multiple %}
+      <div>
+    {% endif %}
+    {% for item in items %}
+      <div{{ item.attributes.addClass("field--field-s-news-author") }}>{{ item.content }}</div>
+    {% endfor %}
+    {% if multiple %}
+      </div>
+    {% endif %}
+  </div>
+{% endif %}

--- a/templates/stanford_news/field--node--field-s-news-author.html.twig
+++ b/templates/stanford_news/field--node--field-s-news-author.html.twig
@@ -41,12 +41,12 @@
   {% if multiple %}
     <div{{ attributes }}>
       {% for item in items %}
-        <div{{ item.attributes.addClass("field--field-s-news-author") }}>{{ item.content }}</div>
+        <span{{ item.attributes.addClass("field--field-s-news-author") }}>{{ item.content }}</span>
       {% endfor %}
     </div>
   {% else %}
     {% for item in items %}
-      <div{{ attributes.addClass("field--field-s-news-author") }}>{{ item.content }}</div>
+      <span{{ attributes.addClass("field--field-s-news-author") }}>{{ item.content }}</span>
     {% endfor %}
   {% endif %}
 {% else %}
@@ -56,7 +56,7 @@
       <div>
     {% endif %}
     {% for item in items %}
-      <div{{ item.attributes.addClass("field--field-s-news-author") }}>{{ item.content }}</div>
+      <span{{ item.attributes.addClass("field--field-s-news-author") }}>{{ item.content }}</span>
     {% endfor %}
     {% if multiple %}
       </div>

--- a/templates/stanford_news/field--node--field-s-news-category.html.twig
+++ b/templates/stanford_news/field--node--field-s-news-category.html.twig
@@ -1,0 +1,65 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
+
+{% if label_hidden %}
+  {% if multiple %}
+    <div{{ attributes }}>
+      {% for item in items %}
+        <div{{ item.attributes.addClass("field--field-s-news-category") }}>{{ item.content }}</div>
+      {% endfor %}
+    </div>
+  {% else %}
+    {% for item in items %}
+      <div{{ attributes.addClass("field--field-s-news-category") }}>{{ item.content }}</div>
+    {% endfor %}
+  {% endif %}
+{% else %}
+  <div{{ attributes }}>
+    <div{{ title_attributes }}>{{ label }}</div>
+    {% if multiple %}
+      <div>
+    {% endif %}
+    {% for item in items %}
+      <div{{ item.attributes.addClass("field--field-s-news-category") }}>{{ item.content }}</div>
+    {% endfor %}
+    {% if multiple %}
+      </div>
+    {% endif %}
+  </div>
+{% endif %}

--- a/templates/stanford_news/field--node--field-s-news-date.html.twig
+++ b/templates/stanford_news/field--node--field-s-news-date.html.twig
@@ -1,0 +1,65 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
+
+{% if label_hidden %}
+  {% if multiple %}
+    <div{{ attributes }}>
+      {% for item in items %}
+        <div{{ item.attributes.addClass("field--field-s-news-date") }}>{{ item.content }}</div>
+      {% endfor %}
+    </div>
+  {% else %}
+    {% for item in items %}
+      <div{{ attributes.addClass("field--field-s-news-date") }}>{{ item.content }}</div>
+    {% endfor %}
+  {% endif %}
+{% else %}
+  <div{{ attributes }}>
+    <div{{ title_attributes }}>{{ label }}</div>
+    {% if multiple %}
+      <div>
+    {% endif %}
+    {% for item in items %}
+      <div{{ item.attributes.addClass("field--field-s-news-date") }}>{{ item.content }}</div>
+    {% endfor %}
+    {% if multiple %}
+      </div>
+    {% endif %}
+  </div>
+{% endif %}

--- a/templates/stanford_news/field--node--field-s-news-source.html.twig
+++ b/templates/stanford_news/field--node--field-s-news-source.html.twig
@@ -1,0 +1,65 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
+
+{% if label_hidden %}
+  {% if multiple %}
+    <div{{ attributes }}>
+      {% for item in items %}
+        <div{{ item.attributes.addClass("field--field-s-news-source") }}>{{ item.content }}</div>
+      {% endfor %}
+    </div>
+  {% else %}
+    {% for item in items %}
+      <div{{ attributes.addClass("field--field-s-news-source") }}>{{ item.content }}</div>
+    {% endfor %}
+  {% endif %}
+{% else %}
+  <div{{ attributes }}>
+    <div{{ title_attributes }}>{{ label }}</div>
+    {% if multiple %}
+      <div>
+    {% endif %}
+    {% for item in items %}
+      <div{{ item.attributes.addClass("field--field-s-news-source") }}>{{ item.content }}</div>
+    {% endfor %}
+    {% if multiple %}
+      </div>
+    {% endif %}
+  </div>
+{% endif %}

--- a/templates/stanford_news/field--node--field-s-news-sub-title.html.twig
+++ b/templates/stanford_news/field--node--field-s-news-sub-title.html.twig
@@ -1,0 +1,65 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
+
+{% if label_hidden %}
+  {% if multiple %}
+    <div{{ attributes }}>
+      {% for item in items %}
+        <div{{ item.attributes.addClass("field--field-s-news-sub-title") }}>{{ item.content }}</div>
+      {% endfor %}
+    </div>
+  {% else %}
+    {% for item in items %}
+      <div{{ attributes.addClass("field--field-s-news-sub-title") }}>{{ item.content }}</div>
+    {% endfor %}
+  {% endif %}
+{% else %}
+  <div{{ attributes }}>
+    <div{{ title_attributes }}>{{ label }}</div>
+    {% if multiple %}
+      <div>
+    {% endif %}
+    {% for item in items %}
+      <div{{ item.attributes.addClass("field--field-s-news-sub-title") }}>{{ item.content }}</div>
+    {% endfor %}
+    {% if multiple %}
+      </div>
+    {% endif %}
+  </div>
+{% endif %}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Updates to the template layout.

# Needed By (Date)
- Wed EOD

# Urgency
- Moderate / High

# Steps to Test

1. Checkout this branch and the EARTH-404 branch of stanford_components and stanford_paragraph_types and matson
2. Clear caches
3. Revert the above three features
4. Clear caches
5. Edit a news page and fill in any new content (hero photo credit field and new news fields.)
6. Review front end for the fields to show up in the correct order with css classes.

# Affected 
- EARTH-404

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)