### PR TITLE
EARTH-279: Styles for column and callout text paragraph types.

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -418,6 +418,42 @@
     position: absolute;
     top: 35%; }
 
+.stanford-callout-text.text-with-summary {
+  font-size: 1.776889em; }
+
+.stanford-callout-text.field-p-callout-title {
+  position: relative;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  text-transform: uppercase;
+  margin-bottom: 1.5em; }
+  .stanford-callout-text.field-p-callout-title::before {
+    content: '';
+    display: block;
+    position: absolute;
+    bottom: -0.5em;
+    left: 0;
+    width: 20px;
+    height: 2px;
+    background-color: #8c1515; }
+
+.simple-columns__title {
+  position: relative;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  text-transform: uppercase;
+  margin-bottom: 1.2em; }
+  .simple-columns__title::before {
+    content: '';
+    display: block;
+    position: absolute;
+    bottom: -0.75em;
+    width: 20px;
+    height: 2px;
+    background-color: #8c1515; }
+
 .section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;
   height: 2px;
@@ -2120,7 +2156,8 @@
   z-index: 2; }
 
 .simple-columns {
-  color: #9c9d9e; }
+  color: #9c9d9e;
+  vertical-align: top; }
 
 .section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after {
   position: absolute;

--- a/scss/components/callout-text/_callout-text.scss
+++ b/scss/components/callout-text/_callout-text.scss
@@ -1,0 +1,28 @@
+@charset 'UTF-8';
+@import "bourbon";
+
+.stanford-callout-text {
+  &.text-with-summary {
+    font-size: modular_scale(1.2);
+  }
+
+  &.field-p-callout-title {
+    position: relative;
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: 0.2px;
+    text-transform: uppercase;
+    margin-bottom: 1.5em;
+
+    &::before {
+      content: '';
+      display: block;
+      position: absolute;
+      bottom: -0.5em;
+      left: 0;
+      width: 20px;
+      height: 2px;
+      background-color: color(brand);
+    }
+  }
+}

--- a/scss/components/column-text/_column-text.scss
+++ b/scss/components/column-text/_column-text.scss
@@ -1,0 +1,20 @@
+@charset 'UTF-8';
+
+.simple-columns__title {
+  position: relative;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  text-transform: uppercase;
+  margin-bottom: 1.2em;
+
+  &::before {
+    content: '';
+    display: block;
+    position: absolute;
+    bottom: -0.75em;
+    width: 20px;
+    height: 2px;
+    background-color: color(brand);
+  }
+}

--- a/scss/components/components.scss
+++ b/scss/components/components.scss
@@ -32,6 +32,8 @@
   "calendar-block/calendar-block",
   "callout-block/callout-block",
   "callout-card/callout-card",
+  "callout-text/callout-text",
+  "column-text/column-text",
   "quote-card/quote-card",
   "contact-footer/contact-footer",
   "collapsible-menu/collapsible-menu",

--- a/scss/components/simple-columns/_simple-columns.scss
+++ b/scss/components/simple-columns/_simple-columns.scss
@@ -11,5 +11,5 @@
 
 .simple-columns {
   color: color(ash);
-
+  vertical-align: top;
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Styles for callout text and column text paragraphs and their titles.

# Needed By (Date)
- Some time before end of sprint so I can get it up to a dev site for Nick to preview.

# Steps to Test

1. Check branch EARTH-279 of: stanford_components, stanford_paragraph_types, matson
2. Revert `stanford_paragraph_callout_text` & `stanford_paragraph_column_text`
3. Add a column text and a callout text paragraph to a complex page
4. Review for title display.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)