### PR TITLE
Earth 446 masonry

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -1426,12 +1426,12 @@
       border-right: 1px solid #fff; }
     .masonry-block.is-action .masonry-block__social-links, .masonry-block.is-inverted .masonry-block__social-links, .masonry-block.has-background .masonry-block__social-links {
       border-right: 1px solid #fff; }
-  .masonry-block.has-image .tag-item, .masonry-block.is-action .tag-item, .masonry-block.is-inverted .tag-item, .masonry-block.has-background .tag-item {
+  .masonry-block.is-wide .tag-item, .masonry-block.has-image .tag-item, .masonry-block.is-action .tag-item, .masonry-block.is-inverted .tag-item, .masonry-block.has-background .tag-item {
     border-color: #fff;
     color: #fff;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale; }
-    .masonry-block.has-image .tag-item:hover, .masonry-block.has-image .tag-item:active, .masonry-block.has-image .tag-item:focus, .masonry-block.is-action .tag-item:hover, .masonry-block.is-action .tag-item:active, .masonry-block.is-action .tag-item:focus, .masonry-block.is-inverted .tag-item:hover, .masonry-block.is-inverted .tag-item:active, .masonry-block.is-inverted .tag-item:focus, .masonry-block.has-background .tag-item:hover, .masonry-block.has-background .tag-item:active, .masonry-block.has-background .tag-item:focus {
+    .masonry-block.is-wide .tag-item:hover, .masonry-block.is-wide .tag-item:active, .masonry-block.is-wide .tag-item:focus, .masonry-block.has-image .tag-item:hover, .masonry-block.has-image .tag-item:active, .masonry-block.has-image .tag-item:focus, .masonry-block.is-action .tag-item:hover, .masonry-block.is-action .tag-item:active, .masonry-block.is-action .tag-item:focus, .masonry-block.is-inverted .tag-item:hover, .masonry-block.is-inverted .tag-item:active, .masonry-block.is-inverted .tag-item:focus, .masonry-block.has-background .tag-item:hover, .masonry-block.has-background .tag-item:active, .masonry-block.has-background .tag-item:focus {
       background-color: #fff;
       color: #4d4f53; }
   .masonry-block.has-columns .tag-item, .masonry-block.is-full-width .tag-item {

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -1426,6 +1426,20 @@
       border-right: 1px solid #fff; }
     .masonry-block.is-action .masonry-block__social-links, .masonry-block.is-inverted .masonry-block__social-links, .masonry-block.has-background .masonry-block__social-links {
       border-right: 1px solid #fff; }
+  .masonry-block.has-image .tag-item, .masonry-block.is-action .tag-item, .masonry-block.is-inverted .tag-item, .masonry-block.has-background .tag-item {
+    border-color: #fff;
+    color: #fff;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale; }
+    .masonry-block.has-image .tag-item:hover, .masonry-block.has-image .tag-item:active, .masonry-block.has-image .tag-item:focus, .masonry-block.is-action .tag-item:hover, .masonry-block.is-action .tag-item:active, .masonry-block.is-action .tag-item:focus, .masonry-block.is-inverted .tag-item:hover, .masonry-block.is-inverted .tag-item:active, .masonry-block.is-inverted .tag-item:focus, .masonry-block.has-background .tag-item:hover, .masonry-block.has-background .tag-item:active, .masonry-block.has-background .tag-item:focus {
+      background-color: #fff;
+      color: #4d4f53; }
+  .masonry-block.has-columns .tag-item, .masonry-block.is-full-width .tag-item {
+    border-color: #017c92;
+    color: #017c92; }
+    .masonry-block.has-columns .tag-item:hover, .masonry-block.has-columns .tag-item:active, .masonry-block.has-columns .tag-item:focus, .masonry-block.is-full-width .tag-item:hover, .masonry-block.is-full-width .tag-item:active, .masonry-block.is-full-width .tag-item:focus {
+      background-color: #017c92;
+      color: #fff; }
   .masonry-block.is-action {
     background-color: #017c92;
     padding-top: 15px;
@@ -1440,20 +1454,6 @@
     @media only screen and (min-width: 768px) {
       .masonry-block.is-full-width .masonry-block__title {
         font-size: 32px; } }
-  .masonry-block.has-columns .tag-item, .masonry-block.is-full-width .tag-item {
-    border-color: #017c92;
-    color: #017c92; }
-    .masonry-block.has-columns .tag-item:hover, .masonry-block.has-columns .tag-item:active, .masonry-block.has-columns .tag-item:focus, .masonry-block.is-full-width .tag-item:hover, .masonry-block.is-full-width .tag-item:active, .masonry-block.is-full-width .tag-item:focus {
-      background-color: #017c92;
-      color: #fff; }
-  .masonry-block .tag-item {
-    border-color: #fff;
-    color: #fff;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale; }
-    .masonry-block .tag-item:hover, .masonry-block .tag-item:active, .masonry-block .tag-item:focus {
-      background-color: #fff;
-      color: #4d4f53; }
 
 .masonry-block__title {
   font-size: 20px;

--- a/css/theme/stanford-news.css
+++ b/css/theme/stanford-news.css
@@ -57,7 +57,7 @@ h1 {
   @media only screen and (min-width: 1024px) {
     .block--field-s-news-date {
       margin-left: 110px; } }
-  .block--field-s-news-date:after {
+  .block--field-s-news-date::after {
     left: 0;
     transform: none; }
   .block--field-s-news-date .field--field-s-news-date {
@@ -135,11 +135,11 @@ h1 {
       padding-left: 110px; } }
   .field--body > :last-child {
     margin-bottom: 0; }
-  .field--body > p:first-of-type:first-line {
+  .field--body > p::first-of-type:first-line {
     position: relative;
     font-size: 1em;
     letter-spacing: normal; }
-  .field--body > p:first-child:first-letter {
+  .field--body > p::first-child:first-letter {
     letter-spacing: 0;
     font-size: 3em;
     font-weight: bold;
@@ -212,8 +212,8 @@ h1 {
 .layout--basic .field--responsive-image,
 .layout--basic .field--responsive-video {
   position: relative; }
-  .layout--basic .field--responsive-image:after,
-  .layout--basic .field--responsive-video:after {
+  .layout--basic .field--responsive-image::after,
+  .layout--basic .field--responsive-video::after {
     content: '';
     background-color: #FBFBFB;
     position: absolute;

--- a/scss/components/masonry-block/_masonry-block.scss
+++ b/scss/components/masonry-block/_masonry-block.scss
@@ -57,6 +57,36 @@
     }
   }
 
+  &.has-image,
+  &.is-action,
+  &.is-inverted,
+  &.has-background {
+    .tag-item {
+      border-color: color(white);
+      color: color(white);
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+
+      @include on-event {
+        background-color: color(white);
+        color: color(text-active);
+      }
+    }
+  }
+
+  &.has-columns,
+  &.is-full-width {
+    .tag-item {
+      border-color: color(action);
+      color: color(action);
+
+      @include on-event {
+        background-color: color(action);
+        color: color(white);
+      }
+    }
+  }
+
   &.is-action {
     background-color: color(action);
     padding-top: 15px;
@@ -82,31 +112,6 @@
       @include grid-media($media-md) {
         font-size: 32px;
       }
-    }
-  }
-
-  &.has-columns,
-  &.is-full-width {
-    .tag-item {
-      border-color: color(action);
-      color: color(action);
-
-      @include on-event {
-        background-color: color(action);
-        color: color(white);
-      }
-    }
-  }
-
-  .tag-item {
-    border-color: color(white);
-    color: color(white);
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-
-    @include on-event {
-      background-color: color(white);
-      color: color(text-active);
     }
   }
 }

--- a/scss/components/masonry-block/_masonry-block.scss
+++ b/scss/components/masonry-block/_masonry-block.scss
@@ -57,6 +57,7 @@
     }
   }
 
+  &.is-wide,
   &.has-image,
   &.is-action,
   &.is-inverted,

--- a/scss/utilities/mixins/_media-elements.scss
+++ b/scss/utilities/mixins/_media-elements.scss
@@ -62,12 +62,6 @@
   top: 50%;
   left: 50%;
 
-  width: auto !important;
-  height: 100%;
-
-  max-height: none;
-  max-width: none;
-
   min-height: 100%;
   min-width: 100%;
 

--- a/scss/utilities/mixins/_media-elements.scss
+++ b/scss/utilities/mixins/_media-elements.scss
@@ -56,3 +56,22 @@
     height: 100%;
   }
 }
+
+@mixin cover-image() {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+
+  width: auto !important;
+  height: 100%;
+
+  max-height: none;
+  max-width: none;
+
+  min-height: 100%;
+  min-width: 100%;
+
+  transform: translate(-50%, -50%);
+  -ms-transform: translate(-50%, -50%);
+  -webkit-transform: translate(-50%, -50%);
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Refactoring of masonry block component for simpler use via the CMS
- Made all image tag rather than using background images.
- Created 6 Card Types:
1. Simple: Card with image tag and on top of content
2. Wide: Simple card with image on top that spans two columns of the grid
3. Columns: Card with image on either the left or right
4. Full: Card with columns that spans the full grid
5. Large Photo: Card with photo background that spans two columns
6. Tall Photo: Card with photo background that spans multiple rows in the grid
7. Color: Card with no photo and Stanford Red background color

# Needed By (Date)
- n/a

# Steps to Test

1. Download associated Stanford components branch EARTH-446-masonry
2. Load Pattern Library Masonry Grid. Grid is set to random so if you load the page several times you can see various iterations of the cards.
3. You can also preview branch http://earthode43.prod.acquia-sites.com/earth-matters

# Associated Issues and/or People
- Depends on work in Stanford components EARTH-154
- Depends on work in Stanford components branch EARTH-446-masonry
@pookmish @sherakama 