### PR TITLE
EARTH-522 Make whole block clickable

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -1013,6 +1013,18 @@
 .expandable-card__toggle svg use {
   fill: #8c1515; }
 
+.expandable-card__toggle.expandable-card__open {
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  top: 0;
+  left: 0;
+  z-index: 99; }
+  .expandable-card__toggle.expandable-card__open span {
+    position: absolute;
+    bottom: 20px;
+    left: calc(50% - 10px); }
+
 .block--lockup__site-name-and-slogan, .block--lockup__site-slogan {
   border: 0;
   clip: rect(1px, 1px, 1px, 1px);

--- a/scss/components/expandable-card/_expandable-card.scss
+++ b/scss/components/expandable-card/_expandable-card.scss
@@ -36,4 +36,20 @@
   svg use {
     fill: color(brand);
   }
+
+  &.expandable-card__open {
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    top: 0;
+    left: 0;
+    z-index: 99;
+
+    span {
+      position: absolute;
+      bottom: 20px;
+      left: calc(50% - 10px);
+    }
+  }
+
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Made the whole block clickable.
- Its kinda cheating the way i did it. but its a quick fix for now.

# Needed By (Date)
- End of sprint

# Urgency
- Low

# Steps to Test

1. Checkout this branch and same branch in [stanford_components](https://github.com/SU-SWS/stanford_components/pull/95)
2. clear cache
3. review page /patterns/section_expandable_banner to make sure it looks the same and the whole block is clickable.

# Associated Issues and/or People
- https://github.com/SU-SWS/stanford_components/pull/95

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)