### PR TITLE
Pulled hero to top of views pages

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -117,6 +117,7 @@ module.exports = function(grunt) {
           'css/layout/stanford-complex-page.css':           'scss/layout/stanford-complex-page.scss',
           'css/layout/research-area.css':                   'scss/layout/research-area.scss',
           'css/layout/stanford-department.css':             'scss/layout/stanford-department.scss',
+          'css/layout/stanford-view-page.css':             'scss/layout/stanford-view-page.scss',
           'css/layout/home.css':                            'scss/layout/home.scss',
           'css/layout/layout.css':                          'scss/layout/layout.scss',
 

--- a/css/layout/stanford-view-page.css
+++ b/css/layout/stanford-view-page.css
@@ -1,0 +1,7 @@
+#hero-banner:first-child:not(.component-centered-container-margins) {
+  margin-top: -121px; }
+  @media only screen and (min-width: 860px) {
+    #hero-banner:first-child:not(.component-centered-container-margins) {
+      margin-top: -126px; } }
+
+/*# sourceMappingURL=stanford-view-page.css.map */

--- a/matson.libraries.yml
+++ b/matson.libraries.yml
@@ -134,6 +134,12 @@ research_area:
     layout:
       css/layout/research-area.css: {}
 
+stanford_view_page:
+  version: VERSION
+  css:
+    layout:
+      css/layout/stanford-view-page.css: {}
+
 home:
   version: VERSION
   css:

--- a/matson.theme
+++ b/matson.theme
@@ -72,6 +72,10 @@ function matson_page_attachments_alter(array &$attachments) {
       case 'research_area':
         $attachments['#attached']['library'][] = 'matson/research_area';
         break;
+
+      case 'stanford_view_page':
+        $attachments['#attached']['library'][] = 'matson/stanford_view_page';
+        break;
     }
   }
 

--- a/scss/layout/stanford-view-page.scss
+++ b/scss/layout/stanford-view-page.scss
@@ -1,0 +1,9 @@
+@charset 'UTF-8';
+@import "utilities/mixins/hero-banner-node";
+
+// The expectation of the view page is that the hero banner will be at the
+// top of the page each time a complex page is rendered. A few things have to
+// move around to ensure that the banner is in the right place.
+
+// Pop out the tabs from the dom flow so they hover over.
+@include hero-banner-node;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- New view page content type.

# Needed By (Date)
- End of sprint

# Urgency
- Mild

# Steps to Test

1. Checkout this branch and same branch for [blt](https://github.com/stanford-earth/SE3_BLT/pull/84) & [stanford_earth_helper](https://github.com/stanford-earth/stanford_earth_helper/pull/4)
2. drush cim or drush en stanford_earth_views_content
3. create new content type of view page
4. choose an appropriate view and add some top media/text etc
5. verify page looks good.

# Associated Issues and/or People
- https://github.com/stanford-earth/stanford_earth_helper/pull/4
- https://github.com/stanford-earth/SE3_BLT/pull/84

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)