### PR TITLE
EARTH-521: Fixing hairline, header and tablet breakpoint for filmstrip

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -1162,10 +1162,15 @@
     display: block;
     position: absolute;
     top: -1em;
-    left: 0;
+    left: 50%;
+    transform: translateX(-50%);
     width: 20px;
     height: 2px;
     background-color: #f9b002; }
+    @media only screen and (min-width: 768px) {
+      .filmstrip .filmstrip__title::before {
+        left: 0;
+        transform: none; } }
 
 .filmstrip .filmstrip__cards {
   margin: 0 auto; }

--- a/css/layout/home.css
+++ b/css/layout/home.css
@@ -1,6 +1,8 @@
 @media only screen and (min-width: 768px) {
   #filmstrip {
-    margin-top: -150px; } }
+    margin-top: -150px;
+    z-index: 10;
+    position: relative; } }
 
 #filmstrip .filmstrip__cards {
   max-width: 1190px; }

--- a/scss/components/filmstrip/_filmstrip.scss
+++ b/scss/components/filmstrip/_filmstrip.scss
@@ -19,10 +19,16 @@
       display: block;
       position: absolute;
       top: -1em;
-      left: 0;
+      left: 50%;
+      transform: translateX(-50%);
       width: 20px;
       height: 2px;
       background-color: color(emphasis);
+
+      @include grid-media($media-md) {
+        left: 0;
+        transform: none;
+      }
     }
   }
 

--- a/scss/layout/home.scss
+++ b/scss/layout/home.scss
@@ -15,7 +15,10 @@
 #filmstrip {
   @include grid-media($media-md) {
     margin-top: -150px;
+    z-index: 10;
+    position: relative;
   }
+  
   .filmstrip__cards {
     max-width: 1190px;
   }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Started as a bug to fix the z-index for Challenges filmstrip on homepage. Includes tablet breakpoint fix for challenges and mobile header
- Includes adding consistent spacing to components on the homepage.
- 

# Needed By (Date)
- end of sprint

# Steps to Test

1. Visit the homepage. Preview challenges components
2. Scroll the page and review consistency of spacing between components.

# Associated Issues and/or People
- EARTH-521 and EARTH-534
- See complimentary Matson theme branch EARTH-521
- Let me know if you'd rather not add spacers to the components themselves but instead handle as a theme layout option. For now half had spacing and half didn't so I just added it to those where it was missing. I think in the long term it should work like centered-content-container with a default spacing but allow the admin to add more or less based on how it relates to other components on the page.
@sherakama 