### PR TITLE
EARTH-529: Updates to stanford_event content type

### DIFF
--- a/css/theme/stanford-event.css
+++ b/css/theme/stanford-event.css
@@ -1,5 +1,5 @@
 .main-container {
-  margin-top: 50px; }
+  margin-top: 0; }
   @media only screen and (max-width: 575px) {
     .main-container {
       padding: 1em calc(((50% /12) * 0) + 15px); }
@@ -76,6 +76,7 @@
 
 @media only screen and (min-width: 1024px) {
   .content-type__media-container {
+    margin-top: -40px;
     margin-bottom: 70px; } }
 
 .content-type__media-container.left-align-media .content-type__header, .content-type__media-container.right-align-media .content-type__header {

--- a/matson.ui_patterns.yml
+++ b/matson.ui_patterns.yml
@@ -32,6 +32,11 @@ node_stanford_event:
       label: "Sub title"
       type: "text"
       preview: "This is the sub title field"
+    description:
+      description: "Description"
+      label: "Description"
+      type: "text"
+      preview: "This is the description field area. HTML WYSIWYG."
     when:
       description: "When this event is happening"
       label: "When"

--- a/scss/theme/stanford-event/stanford-event.scss
+++ b/scss/theme/stanford-event/stanford-event.scss
@@ -5,7 +5,7 @@
 // Comment out to avoid centering the whole container.
 .main-container {
   @include responsive-container($default-container);
-  margin-top: 50px;
+  margin-top: 0;
 }
 
 .page-title {
@@ -56,6 +56,7 @@
 
 .content-type__media-container {
   @include grid-media($media-lg) {
+    margin-top: -40px;
     margin-bottom: 70px;
   }
 

--- a/templates/stanford_event/stanford-event.html.twig
+++ b/templates/stanford_event/stanford-event.html.twig
@@ -28,6 +28,13 @@
 </div>
 
 <div class="block-matson-content">
+
+  {% if description is not empty %}
+  <div class="content--description">
+    {{ description }}
+  </div>
+  {% endif %}
+
   <dl class="definition-list">
     {% if when is not empty %}
     <dt>{{ 'When'|t }}:</dt>

--- a/templates/stanford_event/stanford-event.html.twig
+++ b/templates/stanford_event/stanford-event.html.twig
@@ -29,26 +29,26 @@
 
 <div class="block-matson-content">
 
-  {% if description is not empty %}
-  <div class="content--description">
+  {% if description|render|striptags|trim is not empty %}
+  <div class="content-description lead-text">
     {{ description }}
   </div>
   {% endif %}
 
   <dl class="definition-list">
-    {% if when is not empty %}
+    {% if when|render|striptags|trim is not empty %}
     <dt>{{ 'When'|t }}:</dt>
     <dd>
       {{ when }}
     </dd>
     {% endif %}
-    {% if where is not empty %}
+    {% if where|render|striptags|trim is not empty %}
     <dt>{{ 'Where'|t }}:</dt>
     <dd>
       {{ where }}
     </dd>
     {% endif %}
-    {% if tags is not empty %}
+    {% if tags|render|striptags|trim is not empty %}
     <dt>{{ 'Tags'|t }}:</dt>
     <dd>
     {% if tags is iterable %}
@@ -64,13 +64,13 @@
     {% endif %}
     </dd>
     {% endif %}
-    {% if audience is not empty %}
+    {% if audience|render|striptags|trim is not empty %}
     <dt>{{ 'Audience'|t }}:</dt>
     <dd>
       {{ audience }}
     </dd>
     {% endif %}
-    {% if more_info is not empty %}
+    {% if more_info|render|striptags|trim is not empty %}
     <dt>{{ 'More Info'|t }}:</dt>
     <dd>
       {{ more_info }}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Field and display changes to stanford_event content type.

# Needed By (Date)
- Before end of the week please and thanks.

# Steps to Test

1. Check out this branch and EARTH-529 of the SE3_BLT
2. Sync configuration (drush cim) and clear cache (drush cr)
3. Create a new event node
4. Review display of node

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
