### PR TITLE
EARTH-647: Changing text color for accessibility, mostly ash to stone.

### DIFF
--- a/css/base/base.css
+++ b/css/base/base.css
@@ -1099,4 +1099,7 @@ hr {
   margin: 0 1.776889em;
   line-height: 1.4em; }
 
+body {
+  color: #4d4f53; }
+
 /*# sourceMappingURL=base.css.map */

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -3319,7 +3319,7 @@
   z-index: 2; }
 
 .simple-columns {
-  color: #9c9d9e;
+  color: #4d4f53;
   vertical-align: top; }
 
 .block--lockup__site-name-and-slogan, .block--lockup__site-slogan {

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -401,7 +401,7 @@
       .callout-block .callout-block__title a:hover, .callout-block .callout-block__title a:active, .callout-block .callout-block__title a:focus {
         text-decoration: none; }
   .callout-block .callout-block__intro {
-    color: #9c9d9e;
+    color: #4d4f53;
     font-size: 0.75em;
     text-transform: uppercase; }
   .callout-block .callout-block__name {
@@ -541,6 +541,9 @@
     height: 2px;
     background-color: #8c1515; }
 
+.simple-columns {
+  color: #4d4f53; }
+
 .simple-columns__title {
   position: relative;
   font-size: 14px;
@@ -590,7 +593,7 @@
 .quote-card {
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1); }
   .quote-card p {
-    color: #9c9d9e; }
+    color: #4d4f53; }
 
 .quote-card__icon {
   color: #8c1414; }
@@ -816,7 +819,7 @@
       font-weight: 800;
       letter-spacing: 3px;
       padding: 1em 0;
-      opacity: .5;
+      opacity: .8;
       text-transform: uppercase; }
       @media only screen and (min-width: 768px) {
         .contact-footer__links .menu a {
@@ -1033,7 +1036,7 @@
   font-size: 32px; }
 
 .editorial-sidebar .simple-block__image-caption {
-  color: #9c9d9e; }
+  color: #4d4f53; }
 
 .editorial-sidebar .simple-block__description {
   font-size: 20px;
@@ -1196,8 +1199,11 @@
 .film-card__subtitle {
   margin-bottom: 0; }
 
+.film-card__link {
+  color: #fff; }
+
 .film-card__description {
-  color: #9c9d9e;
+  color: #4d4f53;
   letter-spacing: .5px;
   padding-top: 5px;
   margin-bottom: 0; }
@@ -1233,7 +1239,8 @@
   z-index: 2; }
 
 .filmstrip .filmstrip__title {
-  position: relative; }
+  position: relative;
+  color: #4d4f53; }
   .filmstrip .filmstrip__title::before {
     content: '';
     display: block;
@@ -1677,7 +1684,7 @@
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
   padding: 30px 30px 20px; }
   .highlight-banner__container .highlight-cards .highlight-card p {
-    color: #9c9d9e;
+    color: #4d4f53;
     letter-spacing: 0.5px;
     line-height: 2em;
     margin-bottom: 0.5em; }
@@ -1796,7 +1803,7 @@
   margin-bottom: 20px; }
 
 .paragraph--type--inline-image .field-caption {
-  color: #9c9d9e; }
+  color: #4d4f53; }
 
 .block--lockup__site-name-and-slogan, .block--lockup__site-slogan {
   border: 0;
@@ -2492,7 +2499,7 @@
     padding: 25px 0;
     background-color: transparent; }
   .postcard .postcard__content-text {
-    color: #9c9d9e;
+    color: #4d4f53;
     background-color: #fff;
     line-height: 2em;
     text-align: center; }
@@ -2663,7 +2670,7 @@
 .photo-tiles__quote {
   padding-top: 3em;
   position: relative;
-  color: #9c9d9e; }
+  color: #4d4f53; }
   .photo-tiles__quote > * {
     letter-spacing: .5px;
     line-height: 1.5em; }
@@ -2754,7 +2761,7 @@
   padding-bottom: 2.875em; }
 
 .field-p-responsive-image-cred {
-  color: #9c9d9e;
+  color: #4d4f53;
   text-align: right; }
 
 .block--lockup__site-name-and-slogan, .block--lockup__site-slogan {
@@ -3019,7 +3026,7 @@
   .section-header h2.has-dash-emphasis::after {
     background-color: #f9b002; }
   .section-header p {
-    color: #9c9d9e;
+    color: #4d4f53;
     line-height: 1.375em;
     letter-spacing: 0.5px; }
   .section-header a {
@@ -3265,7 +3272,7 @@
     margin: 0; }
 
 .simple-block__description {
-  color: #9c9d9e;
+  color: #4d4f53;
   letter-spacing: .5px;
   margin-bottom: 4px; }
 
@@ -3631,7 +3638,8 @@ ul.tabs {
   z-index: 2; }
 
 .field-p-wysiwyg {
-  padding-bottom: 2.875em; }
+  padding-bottom: 2.875em;
+  color: #4d4f53; }
   .field-p-wysiwyg > :last-child {
     margin-bottom: 0; }
   .field-p-wysiwyg p {

--- a/scss/base/_typography.scss
+++ b/scss/base/_typography.scss
@@ -327,5 +327,5 @@ $su-brand-Stanford: "\1f57d";
 }
 
 body {
-    color: color(stone);
+  color: color(stone);
 }

--- a/scss/base/_typography.scss
+++ b/scss/base/_typography.scss
@@ -325,3 +325,7 @@ $su-brand-Stanford: "\1f57d";
   margin: 0 modular-scale(2);
   line-height: 1.4em;
 }
+
+body {
+	color: color(stone);
+}

--- a/scss/base/_typography.scss
+++ b/scss/base/_typography.scss
@@ -327,5 +327,5 @@ $su-brand-Stanford: "\1f57d";
 }
 
 body {
-	color: color(stone);
+    color: color(stone);
 }

--- a/scss/components/callout-block/_callout-block.scss
+++ b/scss/components/callout-block/_callout-block.scss
@@ -49,7 +49,7 @@
   }
 
   .callout-block__intro {
-    color: color(ash);
+    color: color(stone);
     font-size: em(12px);
     text-transform: uppercase;
   }

--- a/scss/components/column-text/_column-text.scss
+++ b/scss/components/column-text/_column-text.scss
@@ -1,5 +1,9 @@
 @charset 'UTF-8';
 
+.simple-columns {
+	color: color(stone);
+}
+
 .simple-columns__title {
   position: relative;
   font-size: 14px;

--- a/scss/components/column-text/_column-text.scss
+++ b/scss/components/column-text/_column-text.scss
@@ -1,7 +1,7 @@
 @charset 'UTF-8';
 
 .simple-columns {
-	color: color(stone);
+    color: color(stone);
 }
 
 .simple-columns__title {

--- a/scss/components/column-text/_column-text.scss
+++ b/scss/components/column-text/_column-text.scss
@@ -1,7 +1,7 @@
 @charset 'UTF-8';
 
 .simple-columns {
-    color: color(stone);
+  color: color(stone);
 }
 
 .simple-columns__title {

--- a/scss/components/contact-footer/_contact-footer.scss
+++ b/scss/components/contact-footer/_contact-footer.scss
@@ -188,7 +188,7 @@
       font-weight: 800;
       letter-spacing: 3px;
       padding: 1em 0;
-      opacity: .5;
+      opacity: .8;
       text-transform: uppercase;
 
       @include grid-media($media-md) {
@@ -254,3 +254,6 @@
     }
   }
 }
+
+
+

--- a/scss/components/editorial-sidebar/_editorial-sidebar.scss
+++ b/scss/components/editorial-sidebar/_editorial-sidebar.scss
@@ -24,7 +24,7 @@
   }
 
   .simple-block__image-caption {
-    color: color(ash);
+    color: color(stone);
   }
 
   .simple-block__description {

--- a/scss/components/film-card/_film-card.scss
+++ b/scss/components/film-card/_film-card.scss
@@ -30,8 +30,12 @@
   margin-bottom: 0;
 }
 
+.film-card__link {
+	color: color(white);
+}
+
 .film-card__description {
-  color: color(ash);
+  color: color(stone);
   letter-spacing: .5px;
   padding-top: 5px;
   margin-bottom: 0;

--- a/scss/components/film-card/_film-card.scss
+++ b/scss/components/film-card/_film-card.scss
@@ -31,7 +31,7 @@
 }
 
 .film-card__link {
-    color: color(white);
+  color: color(white);
 }
 
 .film-card__description {

--- a/scss/components/film-card/_film-card.scss
+++ b/scss/components/film-card/_film-card.scss
@@ -31,7 +31,7 @@
 }
 
 .film-card__link {
-	color: color(white);
+    color: color(white);
 }
 
 .film-card__description {

--- a/scss/components/filmstrip/_filmstrip.scss
+++ b/scss/components/filmstrip/_filmstrip.scss
@@ -13,7 +13,7 @@
 .filmstrip {
   .filmstrip__title {
     position: relative;
-	color: color(stone);
+    color: color(stone);
 
     &::before {
       content: '';

--- a/scss/components/filmstrip/_filmstrip.scss
+++ b/scss/components/filmstrip/_filmstrip.scss
@@ -13,6 +13,7 @@
 .filmstrip {
   .filmstrip__title {
     position: relative;
+	color: color(stone);
 
     &::before {
       content: '';

--- a/scss/components/highlight-banner/_highlight-banner.scss
+++ b/scss/components/highlight-banner/_highlight-banner.scss
@@ -16,7 +16,7 @@
       padding: 30px 30px 20px;
 
       p {
-        color: color(ash);
+        color: color(stone);
         letter-spacing: 0.5px;
         line-height: 2em;
         margin-bottom: 0.5em;

--- a/scss/components/inline-image/_inline-image.scss
+++ b/scss/components/inline-image/_inline-image.scss
@@ -15,6 +15,6 @@
   }
 
   .field-caption {
-    color: color(ash);
+    color: color(stone);
   }
 }

--- a/scss/components/photo-tile/_photo-tile.scss
+++ b/scss/components/photo-tile/_photo-tile.scss
@@ -57,7 +57,7 @@
 .photo-tiles__quote {
   padding-top: 3em;
   position: relative;
-  color: color(ash);
+  color: color(stone);
 
   > * {
     letter-spacing: .5px;

--- a/scss/components/postcard/_postcard.scss
+++ b/scss/components/postcard/_postcard.scss
@@ -19,7 +19,7 @@
   }
 
   .postcard__content-text {
-    color: color(ash);
+    color: color(stone);
     background-color: color(white);
     line-height: 2em;
     text-align: center;

--- a/scss/components/quote-card/_quote-card.scss
+++ b/scss/components/quote-card/_quote-card.scss
@@ -13,7 +13,7 @@
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
 
   p {
-    color: color(ash);
+    color: color(stone);
   }
 }
 

--- a/scss/components/responsive-media/_responsive-media.scss
+++ b/scss/components/responsive-media/_responsive-media.scss
@@ -32,6 +32,6 @@
 }
 
 .field-p-responsive-image-cred {
-  color: color(ash);
+  color: color(stone);
   text-align: right;
 }

--- a/scss/components/section-header/_section-header.scss
+++ b/scss/components/section-header/_section-header.scss
@@ -32,7 +32,7 @@
   }
 
   p {
-    color: color(ash);
+    color: color(stone);
     line-height: em(22px);
     letter-spacing: 0.5px;
   }

--- a/scss/components/simple-block/_simple-block.scss
+++ b/scss/components/simple-block/_simple-block.scss
@@ -37,7 +37,7 @@
 }
 
 .simple-block__description {
-  color: color(ash);
+  color: color(stone);
   letter-spacing: .5px;
   margin-bottom: 4px;
 }

--- a/scss/components/simple-columns/_simple-columns.scss
+++ b/scss/components/simple-columns/_simple-columns.scss
@@ -10,6 +10,6 @@
 @import "utilities/utilities";
 
 .simple-columns {
-  color: color(ash);
+  color: color(stone);
   vertical-align: top;
 }

--- a/scss/components/wysiwyg/_wysiwyg.scss
+++ b/scss/components/wysiwyg/_wysiwyg.scss
@@ -12,6 +12,7 @@
 // Content styles
 .field-p-wysiwyg {
   padding-bottom: em(46px);
+  color: color(stone);
 
   > :last-child {
     margin-bottom: 0;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This changes the text colors throughout to be both bolder and more accessible. This includes many of the paragraph type descriptions, the WYSIWIG text, and the footer links. In most cases, the text was changed from Ash to Stone. A base color was also added to body to avoid having pure black text pop up in the event that something was un-styled.

# Needed By (Date)
- No urgency. Some of these changes are present in CSS injector currently.

# Urgency
- Not urgent.

# Steps to Test

1. Go to the Earth Home page
2. Look at the footer links. They should be changed from .5 opacity to .8
3. Look at all multi-line text on the home page. It should be #4d4f53.
4. Go to /academics/undergraduates
5.  Look at all multi-line text the undergrad page. It should be #4d4f53.

# Affected Projects or Products
- None

# Associated Issues and/or People
- EARTH-647

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)