### PR TITLE
EARTH-667: Adjusting size, color, border of social media icons

### DIFF
--- a/css/base/base.css
+++ b/css/base/base.css
@@ -753,8 +753,8 @@ dl > dt {
   fill: currentcolor;
   position: relative;
   stroke-width: 0;
-  height: 1em;
-  width: 1em; }
+  height: 2em;
+  width: 2em; }
   .i-svg.is-red use {
     fill: #8c1515; }
   .i-svg.is-white use {
@@ -767,8 +767,8 @@ dl > dt {
 .i-svg--twitter,
 .i-svg--fb,
 .i-svg--instagram {
-  height: 1.125em;
-  width: 1.125em; }
+  height: 1.875em;
+  width: 1.875em; }
 
 .i-svg--player {
   height: 4.0625em;

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -1969,7 +1969,7 @@
       color: rgba(255, 255, 255, 0.65); }
     .masonry-block.is-action .masonry-block__footer, .masonry-block.is-inverted .masonry-block__footer, .masonry-block.has-background .masonry-block__footer {
       border-top: 1px solid rgba(255, 255, 255, 0.5);
-      margin: 0 11px; }
+      margin: 0 15px; }
     .masonry-block.is-action .masonry-block__arrow:hover svg use, .masonry-block.is-action .masonry-block__arrow:active svg use, .masonry-block.is-action .masonry-block__arrow:focus svg use,
     .masonry-block.is-action .masonry-block__social-link:hover svg use,
     .masonry-block.is-action .masonry-block__social-link:active svg use,
@@ -3357,10 +3357,13 @@
   padding: 0 10px 0 0; }
 
 .social-actions svg {
-  height: 13px;
+  height: 1.6em;
+  color: #017c92;
   vertical-align: middle;
   display: inline;
   margin-top: -3px; }
+  .social-actions svg:hover {
+    opacity: .8; }
 
 .block--lockup__site-name-and-slogan, .block--lockup__site-slogan {
   border: 0;

--- a/css/theme/stanford-event.css
+++ b/css/theme/stanford-event.css
@@ -1,32 +1,14 @@
-.content-type__header .social-actions::after {
-  position: absolute;
-  height: 2px;
-  width: 20px;
-  content: '';
-  display: block;
-  z-index: 2; }
-
-.content-type__header .social-actions::after {
-  position: absolute;
-  height: 2px;
-  width: 20px;
-  content: '';
-  display: block;
-  z-index: 2; }
-
 .content-type__header {
   color: #4d4f53;
   position: relative; }
   .content-type__header .page-title {
     margin-top: 10px; }
   .content-type__header .social-actions {
-    margin-bottom: 1.25em;
-    position: relative; }
-    .content-type__header .social-actions::after {
-      background-color: #8c1515;
-      bottom: -.5em;
-      left: 50%;
-      transform: translateX(-50%); }
+    position: relative;
+    border-bottom: 0.5px solid #9c9d9e;
+    border-top: 0.5px solid #9c9d9e;
+    padding: 10px;
+    margin-top: 10px; }
     .content-type__header .social-actions::after {
       left: 0;
       transform: none; }

--- a/css/theme/stanford-news.css
+++ b/css/theme/stanford-news.css
@@ -1,4 +1,4 @@
-.content-type__header .social-actions::after, .block--field-s-news-date::after, .field-p-wysiwyg h2::after {
+.field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -6,7 +6,7 @@
   display: block;
   z-index: 2; }
 
-.content-type__header .social-actions::after, .block--field-s-news-date::after, .field-p-wysiwyg h2::after {
+.field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -20,13 +20,11 @@
   .content-type__header .page-title {
     margin-top: 10px; }
   .content-type__header .social-actions {
-    margin-bottom: 1.25em;
-    position: relative; }
-    .content-type__header .social-actions::after {
-      background-color: #8c1515;
-      bottom: -.5em;
-      left: 50%;
-      transform: translateX(-50%); }
+    position: relative;
+    border-bottom: 0.5px solid #9c9d9e;
+    border-top: 0.5px solid #9c9d9e;
+    padding: 10px;
+    margin-top: 10px; }
     .content-type__header .social-actions::after {
       left: 0;
       transform: none; }
@@ -161,7 +159,7 @@
   color: #4d4f53; }
 
 .field-s-news-top-media {
-  color: #9c9d9e;
+  color: #4d4f53;
   margin-top: 50px; }
 
 h1 {
@@ -175,13 +173,11 @@ h1 {
       padding-left: 110px; } }
 
 .block--field-s-news-date {
-  margin-bottom: 1.25em;
-  position: relative; }
-  .block--field-s-news-date::after {
-    background-color: #8c1515;
-    bottom: -.5em;
-    left: 50%;
-    transform: translateX(-50%); }
+  position: relative;
+  border-bottom: 0.5px solid #9c9d9e;
+  border-top: 0.5px solid #9c9d9e;
+  padding: 10px;
+  margin-top: 10px; }
   @media only screen and (min-width: 1024px) {
     .block--field-s-news-date {
       margin-left: 110px; } }
@@ -191,7 +187,9 @@ h1 {
   .block--field-s-news-date .field--field-s-news-date {
     display: inline-block; }
     .block--field-s-news-date .field--field-s-news-date svg {
-      margin-right: .5rem; }
+      margin-right: .5rem;
+      height: 1.6em;
+      color: #017c92; }
   .block--field-s-news-date .field--field-s-news-date__actions {
     display: inline-block;
     padding-right: 5px;
@@ -203,10 +201,13 @@ h1 {
     padding: 0 5px;
     color: #4d4f53; }
   .block--field-s-news-date svg {
-    height: 13px;
+    height: 1.6em;
     vertical-align: middle;
     display: inline;
-    margin-top: -3px; }
+    margin-top: -3px;
+    color: #017c92; }
+    .block--field-s-news-date svg:hover {
+      opacity: .8; }
 
 .field-earth-matters-topic {
   text-transform: uppercase; }
@@ -324,8 +325,8 @@ figure.align-center .figure-container {
   text-decoration: underline; }
 
 .field-p-responsive-image-cred {
-  color: #9c9d9e;
-  text-align: right; }
+  color: #4d4f53;
+  text-align: left; }
 
 .simple-columns {
   color: #4d4f53; }

--- a/css/theme/stanford-person.css
+++ b/css/theme/stanford-person.css
@@ -1,4 +1,4 @@
-.content-type__header .social-actions::after, .dash-header::after {
+.dash-header::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -6,7 +6,7 @@
   display: block;
   z-index: 2; }
 
-.content-type__header .social-actions::after, .dash-header::after {
+.dash-header::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -20,13 +20,11 @@
   .content-type__header .page-title {
     margin-top: 10px; }
   .content-type__header .social-actions {
-    margin-bottom: 1.25em;
-    position: relative; }
-    .content-type__header .social-actions::after {
-      background-color: #8c1515;
-      bottom: -.5em;
-      left: 50%;
-      transform: translateX(-50%); }
+    position: relative;
+    border-bottom: 0.5px solid #9c9d9e;
+    border-top: 0.5px solid #9c9d9e;
+    padding: 10px;
+    margin-top: 10px; }
     .content-type__header .social-actions::after {
       left: 0;
       transform: none; }

--- a/css/theme/stanford-spotlight.css
+++ b/css/theme/stanford-spotlight.css
@@ -1,32 +1,14 @@
-.content-type__header .social-actions::after {
-  position: absolute;
-  height: 2px;
-  width: 20px;
-  content: '';
-  display: block;
-  z-index: 2; }
-
-.content-type__header .social-actions::after {
-  position: absolute;
-  height: 2px;
-  width: 20px;
-  content: '';
-  display: block;
-  z-index: 2; }
-
 .content-type__header {
   color: #4d4f53;
   position: relative; }
   .content-type__header .page-title {
     margin-top: 10px; }
   .content-type__header .social-actions {
-    margin-bottom: 1.25em;
-    position: relative; }
-    .content-type__header .social-actions::after {
-      background-color: #8c1515;
-      bottom: -.5em;
-      left: 50%;
-      transform: translateX(-50%); }
+    position: relative;
+    border-bottom: 0.5px solid #9c9d9e;
+    border-top: 0.5px solid #9c9d9e;
+    padding: 10px;
+    margin-top: 10px; }
     .content-type__header .social-actions::after {
       left: 0;
       transform: none; }

--- a/scss/base/_svg.scss
+++ b/scss/base/_svg.scss
@@ -16,8 +16,8 @@
   fill: currentcolor;
   position: relative;
   stroke-width: 0;
-  height: 1em;
-  width: 1em;
+  height: 2em;
+  width: 2em;
 
   &.is-red {
     use {
@@ -47,8 +47,8 @@
 .i-svg--twitter,
 .i-svg--fb,
 .i-svg--instagram {
-  height: em(18px);
-  width: em(18px);
+  height: em(30px);
+  width: em(30px);
 }
 
 .i-svg--player {

--- a/scss/components/content-type/_content-type.scss
+++ b/scss/components/content-type/_content-type.scss
@@ -18,8 +18,11 @@
   }
 
   .social-actions {
-    @include dash-under;
     position: relative;
+    border-bottom: .5px solid color(ash);
+    border-top: .5px solid color(ash);
+    padding: 10px;
+    margin-top: 10px;
 
     &::after {
       left: 0;

--- a/scss/components/masonry-block/_masonry-block.scss
+++ b/scss/components/masonry-block/_masonry-block.scss
@@ -33,7 +33,7 @@
 
     .masonry-block__footer {
       border-top: 1px solid rgba(255, 255, 255, .5);
-      margin: 0 11px;
+      margin: 0 15px;
     }
 
     .masonry-block__arrow,

--- a/scss/components/social-actions/_social-actions.scss
+++ b/scss/components/social-actions/_social-actions.scss
@@ -16,9 +16,14 @@
   }
 
   svg {
-    height: 13px;
+    height: 1.6em;
+    color: color(action);
     vertical-align: middle;
     display: inline;
     margin-top: -3px;
+
+    &:hover {
+      opacity: .8;
+    }
   }
 }

--- a/scss/theme/stanford-news.scss
+++ b/scss/theme/stanford-news.scss
@@ -26,7 +26,7 @@
 
 // Top media and Banner caption
 .field-s-news-top-media {
-  color: color(ash);
+  color: color(stone);
   margin-top: 50px;
 }
 
@@ -48,8 +48,11 @@ h1 {
 
 // Date field.
 .block--field-s-news-date {
-  @include dash-under;
   position: relative;
+  border-bottom: .5px solid color(ash);
+  border-top: .5px solid color(ash);
+  padding: 10px;
+  margin-top: 10px;
 
   @include grid-media($media-lg) {
     margin-left: 110px;
@@ -66,6 +69,8 @@ h1 {
 
     svg {
       margin-right: .5rem;
+      height: 1.6em;
+      color: color(action);
     }
   }
 
@@ -85,10 +90,15 @@ h1 {
   }
 
   svg {
-    height: 13px;
+    height: 1.6em;
     vertical-align: middle;
     display: inline;
     margin-top: -3px;
+    color: color(action);
+
+    &:hover {
+      opacity: .8;
+    }
   }
 }
 
@@ -218,8 +228,8 @@ figure.align-center .figure-container {
 }
 
 .field-p-responsive-image-cred {
-  color: color(ash);
-  text-align: right;
+  color: color(stone);
+  text-align: left;
 }
 
 // Simple columns


### PR DESCRIPTION

# READY FOR REVIEW

# Summary
- This changes the size, color, and border around the social media icons on the individual news, events, and spotlight pages, and also increases the size of the icons in the footer. It also removes the "dash after" style since that was removed by request.

# Needed By: no urgency

# Urgency
- This PR is currently similar to CSS injector stuff that is doing the same thing.

# Steps to Test

1. Go to global footer and look at the size of the white social media icons and make sure they are 1.875em
2. Go to a spotlights page and check to make sure icons are 1.6em and teal, with a border around the social actions area
3. Go to a news page and check to make sure icons are 1.6em and teal, with a border around the area
4. Make a test event with a non /events path name, check to make sure icons are 1.6em and teal, with a border around the area
5. Also fixed a case where a photo caption was still ash.

# Affected Projects or Products
- No effect!

# Associated Issues and/or People
- EARTH-667

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)