### PR TITLE
EARTH-708: Adjusting spotlight theming

### DIFF
--- a/css/theme/stanford-spotlight.css
+++ b/css/theme/stanford-spotlight.css
@@ -200,6 +200,9 @@
 .page-subtitle h2 {
   font-size: 28px; }
 
+.page-subtitle .s-person-name__name {
+  font-weight: bolder; }
+
 .page-subtitle span {
   display: block; }
 
@@ -270,8 +273,10 @@ figcaption {
       width: 150vw; } }
 
 .content-type__media-container.left-align-media .content-type__media .photo-credit, .content-type__media-container.centered-media .content-type__media .photo-credit {
-  margin: -15px 25px 10px 0px;
-  color: #9c9d9e; }
+  margin: -15px 30px 10px 0px;
+  color: #4d4f53;
+  line-height: 1.1em;
+  font-size: .8em; }
   .content-type__media-container.left-align-media .content-type__media .photo-credit::after, .content-type__media-container.centered-media .content-type__media .photo-credit::after {
     margin-bottom: 1.25em; }
     .content-type__media-container.left-align-media .content-type__media .photo-credit::after::after, .content-type__media-container.centered-media .content-type__media .photo-credit::after::after {

--- a/css/theme/stanford-spotlight.css
+++ b/css/theme/stanford-spotlight.css
@@ -1,3 +1,19 @@
+.content-type__media-container.left-align-media .content-type__media .photo-credit::after, .content-type__media-container.centered-media .content-type__media .photo-credit::after {
+  position: absolute;
+  height: 2px;
+  width: 20px;
+  content: '';
+  display: block;
+  z-index: 2; }
+
+.content-type__media-container.left-align-media .content-type__media .photo-credit::after, .content-type__media-container.centered-media .content-type__media .photo-credit::after {
+  position: absolute;
+  height: 2px;
+  width: 20px;
+  content: '';
+  display: block;
+  z-index: 2; }
+
 .content-type__header {
   color: #4d4f53;
   position: relative; }
@@ -190,7 +206,7 @@
 figcaption {
   display: table-caption;
   caption-side: bottom;
-  color: #9c9d9e;
+  color: #4d4f53;
   text-align: right; }
 
 .lead-text {
@@ -252,6 +268,17 @@ figcaption {
       margin-right: -50vw;
       z-index: -1;
       width: 150vw; } }
+
+.content-type__media-container.left-align-media .content-type__media .photo-credit, .content-type__media-container.centered-media .content-type__media .photo-credit {
+  margin: -15px 25px 10px 0px;
+  color: #9c9d9e; }
+  .content-type__media-container.left-align-media .content-type__media .photo-credit::after, .content-type__media-container.centered-media .content-type__media .photo-credit::after {
+    margin-bottom: 1.25em; }
+    .content-type__media-container.left-align-media .content-type__media .photo-credit::after::after, .content-type__media-container.centered-media .content-type__media .photo-credit::after::after {
+      background-color: #8c1515;
+      bottom: -.5em;
+      left: 50%;
+      transform: translateX(-50%); }
 
 .content-type__media-container .content-type-date {
   margin-top: 10px; }

--- a/css/theme/stanford-spotlight.css
+++ b/css/theme/stanford-spotlight.css
@@ -273,7 +273,7 @@ figcaption {
       width: 150vw; } }
 
 .content-type__media-container.left-align-media .content-type__media .photo-credit, .content-type__media-container.centered-media .content-type__media .photo-credit {
-  margin: -15px 30px 10px 0px;
+  margin: -15px 30px 10px 0;
   color: #4d4f53;
   line-height: 1.1em;
   font-size: .8em; }

--- a/scss/theme/stanford-spotlight/stanford-spotlight.scss
+++ b/scss/theme/stanford-spotlight/stanford-spotlight.scss
@@ -23,6 +23,10 @@
     font-size: 28px;
   }
 
+  .s-person-name__name {
+    font-weight:bolder;
+  }
+
   span {
     display: block;
   }
@@ -91,8 +95,10 @@ figcaption {
 
       }
       .photo-credit {
-        margin: -15px 25px 10px 0px;
-        color: color(ash);
+        margin: -15px 30px 10px 0px;
+        color: color(stone);
+        line-height: 1.1em;
+        font-size: .8em;
 
         &::after {
           @include dash-under ($dash-color: brand);

--- a/scss/theme/stanford-spotlight/stanford-spotlight.scss
+++ b/scss/theme/stanford-spotlight/stanford-spotlight.scss
@@ -24,7 +24,7 @@
   }
 
   .s-person-name__name {
-    font-weight:bolder;
+    font-weight: bolder;
   }
 
   span {
@@ -95,7 +95,7 @@ figcaption {
 
       }
       .photo-credit {
-        margin: -15px 30px 10px 0px;
+        margin: -15px 30px 10px 0;
         color: color(stone);
         line-height: 1.1em;
         font-size: .8em;

--- a/scss/theme/stanford-spotlight/stanford-spotlight.scss
+++ b/scss/theme/stanford-spotlight/stanford-spotlight.scss
@@ -31,7 +31,7 @@
 figcaption {
   display: table-caption;
   caption-side: bottom;
-  color: color(ash);
+  color: color(stone);
   text-align: right;
 }
 
@@ -89,6 +89,14 @@ figcaption {
           }
         }
 
+      }
+      .photo-credit {
+        margin: -15px 25px 10px 0px;
+        color: color(ash);
+
+        &::after {
+          @include dash-under ($dash-color: brand);
+        }
       }
     }
   }


### PR DESCRIPTION
# READY FOR REVIEW
# Summary
- This adds styles to the spotlight to make the caption stand out more from the body text. The caption has reduced font size and line spacing, and increased margins. The spotlight "person" name is also bolded to make it stand out from the title. These requests were made by Dee Tucker.

# Needed By (Date)
- As soon as possible. Currently they are not using the caption field.

# Urgency
- It would be nice to get them using this field, but there is not an urgent rush.

# Steps to Test

1. Add a caption to spotlight content
2. Look at the caption
3. Look at the name field


# Associated Issues and/or People
- EARTH-708

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)