### PR TITLE
Earth 687 css fixes

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -1866,6 +1866,13 @@
     @media only screen and (min-width: 1024px) {
       .link-banner__header p {
         margin: 0; } }
+  .link-banner__header a {
+    color: #FFFFFF;
+    opacity: .8; }
+    .link-banner__header a:hover {
+      opacity: 1; }
+  .link-banner__header ul li {
+    color: #FFFFFF; }
 
 .block--lockup__site-name-and-slogan, .block--lockup__site-slogan {
   border: 0;
@@ -3259,6 +3266,9 @@
 
 .simple-block__thumbnail {
   margin-bottom: .5em; }
+
+.simple-block__content p {
+  margin: 0px 0px 0px 0px; }
 
 .simple-block__tag {
   background-color: rgba(0, 0, 0, 0.5);

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -2899,6 +2899,15 @@
   @media only screen and (min-width: 768px) and (max-width: 1023px) {
     .section-expandable-banner .section-header {
       text-align: left; } }
+  .section-expandable-banner .section-header h2, .section-expandable-banner .section-header h3 {
+    color: #fff; }
+  .section-expandable-banner .section-header ul li {
+    color: #fff; }
+  .section-expandable-banner .section-header a {
+    color: #fff;
+    opacity: .8; }
+    .section-expandable-banner .section-header a:hover {
+      opacity: 1; }
   .section-expandable-banner .section-header p {
     color: #fff;
     letter-spacing: .5px;

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -3648,7 +3648,7 @@ ul.tabs {
   .field-p-wysiwyg p {
     margin-bottom: 30px; }
   .field-p-wysiwyg p + h2 {
-    margin-top: 50px; }
+    margin-top: 25px; }
   .field-p-wysiwyg blockquote + h1,
   .field-p-wysiwyg blockquote + h2,
   .field-p-wysiwyg blockquote + h3,
@@ -3656,6 +3656,12 @@ ul.tabs {
   .field-p-wysiwyg blockquote + h5,
   .field-p-wysiwyg blockquote + h6 {
     margin-top: 1em; }
+  @media only screen and (min-width: 576px) {
+    .field-p-wysiwyg h2 {
+      font-size: 1.8em;
+      /* for barb. didn't want to change global line-height, etc*/ }
+    .field-p-wysiwyg h3 {
+      font-size: 1.6em; } }
   .field-p-wysiwyg figure {
     display: table;
     margin-bottom: 30px; }

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -1872,12 +1872,12 @@
       .link-banner__header p {
         margin: 0; } }
   .link-banner__header a {
-    color: #FFFFFF;
+    color: #FFF;
     opacity: .8; }
     .link-banner__header a:hover {
       opacity: 1; }
   .link-banner__header ul li {
-    color: #FFFFFF; }
+    color: #FFF; }
 
 .block--lockup__site-name-and-slogan, .block--lockup__site-slogan {
   border: 0;
@@ -2904,7 +2904,8 @@
   @media only screen and (min-width: 768px) and (max-width: 1023px) {
     .section-expandable-banner .section-header {
       text-align: left; } }
-  .section-expandable-banner .section-header h2, .section-expandable-banner .section-header h3 {
+  .section-expandable-banner .section-header h2,
+  .section-expandable-banner .section-header h3 {
     color: #fff; }
   .section-expandable-banner .section-header ul li {
     color: #fff; }
@@ -3282,7 +3283,7 @@
   margin-bottom: .5em; }
 
 .simple-block__content p {
-  margin: 0px 0px 0px 0px; }
+  margin: 0 0 0 0; }
 
 .simple-block__tag {
   background-color: rgba(0, 0, 0, 0.5);
@@ -3681,10 +3682,9 @@ ul.tabs {
   .field-p-wysiwyg blockquote + h6 {
     margin-top: 1em; }
   .field-p-wysiwyg h2 {
-    font-size: 1.8em;
-    /* for barb. didn't want to change global line-height, etc*/
     position: relative;
-    padding-left: .9em; }
+    padding-left: .9em;
+    font-size: 1.8em; }
     .field-p-wysiwyg h2::after {
       position: absolute;
       top: 50%;
@@ -3697,73 +3697,64 @@ ul.tabs {
       left: 0; }
   .field-p-wysiwyg h3 {
     font-size: 1.6em; }
-
-figure {
-  display: table;
-  margin-bottom: 30px; }
-  figure.align-right {
-    margin-left: 30px; }
-  figure.align-left {
-    margin-right: 30px; }
-
-figure.align-left img[data-responsive-image-style="landscape"],
-figure.align-left img[data-responsive-image-style="portrait"],
-figure.align-right img[data-responsive-image-style="landscape"],
-figure.align-right img[data-responsive-image-style="portrait"] {
-  width: 100%; }
-
-figcaption {
-  display: table-caption;
-  caption-side: bottom;
-  color: #9c9d9e;
-  text-align: left; }
-
-img {
-  margin-bottom: 20px; }
-  img.align-right {
-    margin-left: 20px; }
-  img.align-left {
-    margin-right: 20px; }
-
-img[data-responsive-image-style="landscape"],
-img[data-responsive-image-style="portrait"] {
-  width: calc(50% - 20px); }
-
-img[data-responsive-image-style="wide"] {
-  width: 100%;
-  min-width: 100%; }
-  img[data-responsive-image-style="wide"].align-right {
-    margin-left: 0; }
-  img[data-responsive-image-style="wide"].align-left {
-    margin-right: 0; }
-
-h2,
-h3,
-h4,
-h5,
-h6 {
-  clear: both; }
-
-h3.teal, h2.teal {
-  color: #017c92; }
-
-h2.cardinal, h3.cardinal {
-  color: #8c1515; }
-
-div.well-insert {
-  background-color: #F9F6EF;
-  float: left;
-  clear: none;
-  width: 30%;
-  padding: 15px;
-  margin: 15px; }
-
-div.well-insert-right {
-  background-color: #F9F6EF;
-  float: right;
-  clear: none;
-  width: 30%;
-  padding: 15px;
-  margin: 15px; }
+  .field-p-wysiwyg figure {
+    display: table;
+    margin-bottom: 30px; }
+    .field-p-wysiwyg figure.align-right {
+      margin-left: 30px; }
+    .field-p-wysiwyg figure.align-left {
+      margin-right: 30px; }
+  .field-p-wysiwyg figure.align-left img[data-responsive-image-style="landscape"],
+  .field-p-wysiwyg figure.align-left img[data-responsive-image-style="portrait"],
+  .field-p-wysiwyg figure.align-right img[data-responsive-image-style="landscape"],
+  .field-p-wysiwyg figure.align-right img[data-responsive-image-style="portrait"] {
+    width: 100%; }
+  .field-p-wysiwyg figcaption {
+    display: table-caption;
+    caption-side: bottom;
+    color: #4d4f53;
+    text-align: left; }
+  .field-p-wysiwyg img {
+    margin-bottom: 20px; }
+    .field-p-wysiwyg img.align-right {
+      margin-left: 20px; }
+    .field-p-wysiwyg img.align-left {
+      margin-right: 20px; }
+  .field-p-wysiwyg img[data-responsive-image-style="landscape"],
+  .field-p-wysiwyg img[data-responsive-image-style="portrait"] {
+    width: calc(50% - 20px); }
+  .field-p-wysiwyg img[data-responsive-image-style="wide"] {
+    width: 100%;
+    min-width: 100%; }
+    .field-p-wysiwyg img[data-responsive-image-style="wide"].align-right {
+      margin-left: 0; }
+    .field-p-wysiwyg img[data-responsive-image-style="wide"].align-left {
+      margin-right: 0; }
+  .field-p-wysiwyg h2,
+  .field-p-wysiwyg h3,
+  .field-p-wysiwyg h4,
+  .field-p-wysiwyg h5,
+  .field-p-wysiwyg h6 {
+    clear: both; }
+  .field-p-wysiwyg h3.teal,
+  .field-p-wysiwyg h2.teal {
+    color: #017c92; }
+  .field-p-wysiwyg h2.cardinal,
+  .field-p-wysiwyg h3.cardinal {
+    color: #8c1515; }
+  .field-p-wysiwyg div.well-insert {
+    background-color: #F9F6EF;
+    float: left;
+    clear: none;
+    width: 30%;
+    padding: 15px;
+    margin: 15px; }
+  .field-p-wysiwyg div.well-insert-right {
+    background-color: #F9F6EF;
+    float: right;
+    clear: none;
+    width: 30%;
+    padding: 15px;
+    margin: 15px; }
 
 /*# sourceMappingURL=components.css.map */

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -9,7 +9,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -244,7 +244,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -292,7 +292,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -368,7 +368,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -450,7 +450,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -582,7 +582,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -926,7 +926,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -990,7 +990,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1064,7 +1064,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1127,7 +1127,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1179,7 +1179,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1230,7 +1230,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1294,7 +1294,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1474,7 +1474,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1509,7 +1509,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1542,7 +1542,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1672,7 +1672,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1739,7 +1739,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1791,7 +1791,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1827,7 +1827,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1889,7 +1889,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -1943,7 +1943,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -2142,7 +2142,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -2272,7 +2272,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -2381,7 +2381,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -2485,7 +2485,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -2540,7 +2540,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -2576,7 +2576,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -2624,7 +2624,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -2724,7 +2724,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -2786,7 +2786,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -2878,7 +2878,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -2953,7 +2953,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -2986,7 +2986,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -3056,7 +3056,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -3103,7 +3103,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -3148,7 +3148,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -3243,7 +3243,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -3310,7 +3310,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -3344,7 +3344,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -3387,7 +3387,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -3448,7 +3448,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -3496,7 +3496,7 @@
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -3585,7 +3585,7 @@ ul.tabs {
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -3632,7 +3632,7 @@ ul.tabs {
   white-space: nowrap;
   width: 1px; }
 
-.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after {
+.section-header h2.has-dash-under::after, .section-header h2.has-dash-left::after, .section-feature-blocks.left-aligned .section-header h2.has-dash-under::after, .photo-mosaic__header h2.has-dash-under::after, .field-p-wysiwyg h2::after {
   position: absolute;
   height: 2px;
   width: 20px;
@@ -3646,7 +3646,7 @@ ul.tabs {
   .field-p-wysiwyg > :last-child {
     margin-bottom: 0; }
   .field-p-wysiwyg p {
-    margin-bottom: 30px; }
+    margin-bottom: 1em; }
   .field-p-wysiwyg p + h2 {
     margin-top: 25px; }
   .field-p-wysiwyg blockquote + h1,
@@ -3656,50 +3656,90 @@ ul.tabs {
   .field-p-wysiwyg blockquote + h5,
   .field-p-wysiwyg blockquote + h6 {
     margin-top: 1em; }
-  @media only screen and (min-width: 576px) {
-    .field-p-wysiwyg h2 {
-      font-size: 1.8em;
-      /* for barb. didn't want to change global line-height, etc*/ }
-    .field-p-wysiwyg h3 {
-      font-size: 1.6em; } }
-  .field-p-wysiwyg figure {
-    display: table;
-    margin-bottom: 30px; }
-    .field-p-wysiwyg figure.align-right {
-      margin-left: 30px; }
-    .field-p-wysiwyg figure.align-left {
-      margin-right: 30px; }
-  .field-p-wysiwyg figure.align-left img[data-responsive-image-style="landscape"],
-  .field-p-wysiwyg figure.align-left img[data-responsive-image-style="portrait"],
-  .field-p-wysiwyg figure.align-right img[data-responsive-image-style="landscape"],
-  .field-p-wysiwyg figure.align-right img[data-responsive-image-style="portrait"] {
-    width: 100%; }
-  .field-p-wysiwyg figcaption {
-    display: table-caption;
-    caption-side: bottom;
-    color: #9c9d9e;
-    text-align: left; }
-  .field-p-wysiwyg img {
-    margin-bottom: 20px; }
-    .field-p-wysiwyg img.align-right {
-      margin-left: 20px; }
-    .field-p-wysiwyg img.align-left {
-      margin-right: 20px; }
-  .field-p-wysiwyg img[data-responsive-image-style="landscape"],
-  .field-p-wysiwyg img[data-responsive-image-style="portrait"] {
-    width: calc(50% - 20px); }
-  .field-p-wysiwyg img[data-responsive-image-style="wide"] {
-    width: 100%;
-    min-width: 100%; }
-    .field-p-wysiwyg img[data-responsive-image-style="wide"].align-right {
-      margin-left: 0; }
-    .field-p-wysiwyg img[data-responsive-image-style="wide"].align-left {
-      margin-right: 0; }
-  .field-p-wysiwyg h2,
-  .field-p-wysiwyg h3,
-  .field-p-wysiwyg h4,
-  .field-p-wysiwyg h5,
-  .field-p-wysiwyg h6 {
-    clear: both; }
+  .field-p-wysiwyg h2 {
+    font-size: 1.8em;
+    /* for barb. didn't want to change global line-height, etc*/
+    position: relative;
+    padding-left: .9em; }
+    .field-p-wysiwyg h2::after {
+      position: absolute;
+      top: 50%;
+      margin-top: auto;
+      margin-bottom: auto;
+      -webkit-transform: translateY(-50%);
+      -ms-transform: translateY(-50%);
+      transform: translateY(-50%);
+      background-color: #8c1515;
+      left: 0; }
+  .field-p-wysiwyg h3 {
+    font-size: 1.6em; }
+
+figure {
+  display: table;
+  margin-bottom: 30px; }
+  figure.align-right {
+    margin-left: 30px; }
+  figure.align-left {
+    margin-right: 30px; }
+
+figure.align-left img[data-responsive-image-style="landscape"],
+figure.align-left img[data-responsive-image-style="portrait"],
+figure.align-right img[data-responsive-image-style="landscape"],
+figure.align-right img[data-responsive-image-style="portrait"] {
+  width: 100%; }
+
+figcaption {
+  display: table-caption;
+  caption-side: bottom;
+  color: #9c9d9e;
+  text-align: left; }
+
+img {
+  margin-bottom: 20px; }
+  img.align-right {
+    margin-left: 20px; }
+  img.align-left {
+    margin-right: 20px; }
+
+img[data-responsive-image-style="landscape"],
+img[data-responsive-image-style="portrait"] {
+  width: calc(50% - 20px); }
+
+img[data-responsive-image-style="wide"] {
+  width: 100%;
+  min-width: 100%; }
+  img[data-responsive-image-style="wide"].align-right {
+    margin-left: 0; }
+  img[data-responsive-image-style="wide"].align-left {
+    margin-right: 0; }
+
+h2,
+h3,
+h4,
+h5,
+h6 {
+  clear: both; }
+
+h3.teal, h2.teal {
+  color: #017c92; }
+
+h2.cardinal, h3.cardinal {
+  color: #8c1515; }
+
+div.well-insert {
+  background-color: #F9F6EF;
+  float: left;
+  clear: none;
+  width: 30%;
+  padding: 15px;
+  margin: 15px; }
+
+div.well-insert-right {
+  background-color: #F9F6EF;
+  float: right;
+  clear: none;
+  width: 30%;
+  padding: 15px;
+  margin: 15px; }
 
 /*# sourceMappingURL=components.css.map */

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -1872,12 +1872,12 @@
       .link-banner__header p {
         margin: 0; } }
   .link-banner__header a {
-    color: #FFF;
+    color: #fff;
     opacity: .8; }
     .link-banner__header a:hover {
       opacity: 1; }
   .link-banner__header ul li {
-    color: #FFF; }
+    color: #fff; }
 
 .block--lockup__site-name-and-slogan, .block--lockup__site-slogan {
   border: 0;

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -2983,6 +2983,9 @@
   display: block;
   z-index: 2; }
 
+.highlight-card__action:hover {
+  color: #016779; }
+
 .section-highlight-cards__container .highlight-cards .highlight-card {
   box-shadow: none; }
 

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -1238,6 +1238,11 @@
   display: block;
   z-index: 2; }
 
+.filmstrip__header ul {
+  margin-left: 15%; }
+  .filmstrip__header ul li {
+    text-align: left; }
+
 .filmstrip .filmstrip__title {
   position: relative;
   color: #4d4f53; }

--- a/css/theme/stanford-news.css
+++ b/css/theme/stanford-news.css
@@ -253,6 +253,9 @@ h1 {
   .field-s-news-summary > :last-child {
     margin-bottom: 0; }
 
+.section-news .field--body {
+  padding-bottom: 0px; }
+
 @media only screen and (min-width: 576px) {
   .layout--basic .field-p-wysiwyg {
     padding: 0 80px 20px; } }
@@ -338,7 +341,7 @@ figure.align-center .figure-container {
   .highlight-card h5 {
     text-transform: uppercase; }
   .highlight-card p {
-    color: #9c9d9e; }
+    color: #4d4f53; }
   .highlight-card h5,
   .highlight-card p {
     font-size: 13px; }

--- a/css/theme/stanford-news.css
+++ b/css/theme/stanford-news.css
@@ -254,7 +254,7 @@ h1 {
     margin-bottom: 0; }
 
 .section-news .field--body {
-  padding-bottom: 0px; }
+  padding-bottom: 0; }
 
 @media only screen and (min-width: 576px) {
   .layout--basic .field-p-wysiwyg {

--- a/css/theme/stanford-news.css
+++ b/css/theme/stanford-news.css
@@ -174,8 +174,8 @@ h1 {
 
 .block--field-s-news-date {
   position: relative;
-  border-bottom: 0.5px solid #9c9d9e;
-  border-top: 0.5px solid #9c9d9e;
+  border-bottom: 0.5px solid #4d4f53;
+  border-top: 0.5px solid #4d4f53;
   padding: 10px;
   margin-top: 10px; }
   @media only screen and (min-width: 1024px) {

--- a/scss/components/filmstrip/_filmstrip.scss
+++ b/scss/components/filmstrip/_filmstrip.scss
@@ -11,6 +11,17 @@
 
 // Stanford Earth styling for the filmstrip top-border
 .filmstrip {
+  &__header {
+    ul {
+      margin-left: 15%;
+
+      li {
+      text-align: left;
+    }
+    }
+
+  }
+
   .filmstrip__title {
     position: relative;
     color: color(stone);

--- a/scss/components/filmstrip/_filmstrip.scss
+++ b/scss/components/filmstrip/_filmstrip.scss
@@ -16,7 +16,7 @@
       margin-left: 15%;
 
       li {
-      text-align: left;
+        text-align: left;
     }
     }
 

--- a/scss/components/filmstrip/_filmstrip.scss
+++ b/scss/components/filmstrip/_filmstrip.scss
@@ -15,9 +15,9 @@
     ul {
       margin-left: 15%;
 
-        li {
-          text-align: left;
-    }
+      li {
+        text-align: left;
+      }
     }
   }
 

--- a/scss/components/filmstrip/_filmstrip.scss
+++ b/scss/components/filmstrip/_filmstrip.scss
@@ -15,11 +15,10 @@
     ul {
       margin-left: 15%;
 
-      li {
-        text-align: left;
+        li {
+          text-align: left;
     }
     }
-
   }
 
   .filmstrip__title {

--- a/scss/components/link-banner/_link-banner.scss
+++ b/scss/components/link-banner/_link-banner.scss
@@ -42,8 +42,9 @@
     }
 
 }
+
   ul li {
-      color: #FFF;
+    color: #FFF;
 
 }
 

--- a/scss/components/link-banner/_link-banner.scss
+++ b/scss/components/link-banner/_link-banner.scss
@@ -34,7 +34,7 @@
   }
 
   a {
-    color: #FFF;
+    color: color(white);
     opacity: .8;
 
     &:hover {
@@ -44,8 +44,6 @@
 }
 
   ul li {
-    color: #FFF;
-
-}
-
+    color: color(white);
+  }
 }

--- a/scss/components/link-banner/_link-banner.scss
+++ b/scss/components/link-banner/_link-banner.scss
@@ -32,4 +32,17 @@
       margin: 0;
     }
   }
+  a {
+    color: #FFFFFF;
+    opacity: .8;
+
+    &:hover {
+      opacity: 1;
+    }
+}
+ul li {
+  color: #FFFFFF;
+
+}
+
 }

--- a/scss/components/link-banner/_link-banner.scss
+++ b/scss/components/link-banner/_link-banner.scss
@@ -40,8 +40,7 @@
     &:hover {
       opacity: 1;
     }
-
-}
+  }
 
   ul li {
     color: color(white);

--- a/scss/components/link-banner/_link-banner.scss
+++ b/scss/components/link-banner/_link-banner.scss
@@ -32,16 +32,18 @@
       margin: 0;
     }
   }
+
   a {
-    color: #FFFFFF;
+    color: #FFF;
     opacity: .8;
 
     &:hover {
       opacity: 1;
     }
+
 }
-ul li {
-  color: #FFFFFF;
+  ul li {
+      color: #FFF;
 
 }
 

--- a/scss/components/section-expandable-banner/_section-expandable-banner.scss
+++ b/scss/components/section-expandable-banner/_section-expandable-banner.scss
@@ -18,6 +18,23 @@
       text-align: left;
     }
 
+    h2, h3 {
+      color: color(white);
+    }
+
+    ul li {
+      color: color(white);
+    }
+
+    a {
+      color: color(white);
+      opacity: .8;
+
+      &:hover {
+        opacity: 1;
+      }
+    }
+
     p {
       color: color(white);
       letter-spacing: .5px;

--- a/scss/components/section-expandable-banner/_section-expandable-banner.scss
+++ b/scss/components/section-expandable-banner/_section-expandable-banner.scss
@@ -18,7 +18,8 @@
       text-align: left;
     }
 
-    h2, h3 {
+    h2,
+    h3 {
       color: color(white);
     }
 

--- a/scss/components/section-highlight-cards/section-highlight-cards.scss
+++ b/scss/components/section-highlight-cards/section-highlight-cards.scss
@@ -12,6 +12,9 @@
 // .section-highlight-cards__header {
 //
 // }
+.highlight-card__action:hover {
+  color: color(action-active);
+}
 
 .section-highlight-cards__container {
   .highlight-cards {

--- a/scss/components/simple-block/_simple-block.scss
+++ b/scss/components/simple-block/_simple-block.scss
@@ -22,6 +22,12 @@
   margin-bottom: .5em;
 }
 
+.simple-block__content {
+  p {
+  margin: 0px 0px 0px 0px;
+  }
+}
+
 .simple-block__tag {
   background-color: rgba(0, 0, 0, 0.5);
   padding: .625em 1em;

--- a/scss/components/simple-block/_simple-block.scss
+++ b/scss/components/simple-block/_simple-block.scss
@@ -24,7 +24,7 @@
 
 .simple-block__content {
   p {
-  margin: 0px 0px 0px 0px;
+    margin: 0 0 0 0;
   }
 }
 

--- a/scss/components/wysiwyg/_wysiwyg.scss
+++ b/scss/components/wysiwyg/_wysiwyg.scss
@@ -47,9 +47,9 @@
 
 
   // Floated images
-figure {
-  display: table;
-  margin-bottom: 30px;
+  figure {
+    display: table;
+    margin-bottom: 30px;
 
   &.align-right {
     margin-left: 30px;
@@ -121,8 +121,8 @@ figure {
     color: #017c92;
 }
 
-   h2.cardinal,
-   h3.cardinal {
+  h2.cardinal,
+  h3.cardinal {
      color: #8c1515;
 }
 

--- a/scss/components/wysiwyg/_wysiwyg.scss
+++ b/scss/components/wysiwyg/_wysiwyg.scss
@@ -31,7 +31,7 @@
   blockquote + h3,
   blockquote + h4,
   blockquote + h5,
-  blockquote + h6, {
+  blockquote + h6 {
     margin-top: modular-scale(0);
   }
 
@@ -43,8 +43,6 @@
   h3 {
     font-size: 1.6em;
   }
-
-
 
   // Floated images
   figure {
@@ -118,22 +116,22 @@
 //Special styles for Barb to use
   h3.teal,
   h2.teal {
-    color: #017c92;
-}
+    color: color(action);
+  }
 
   h2.cardinal,
   h3.cardinal {
-    color: #8c1515;
-}
+    color: color(brand);
+  }
 
   div.well-insert {
-    background-color: #F9F6EF;
+    background-color: color(sandstone-light);
     float: left;
     clear: none;
     width: 30%;
     padding: 15px;
     margin: 15px;
-}
+  }
 
   div.well-insert-right {
     background-color: #F9F6EF;
@@ -142,5 +140,5 @@
     width: 30%;
     padding: 15px;
     margin: 15px;
-}
+  }
 }

--- a/scss/components/wysiwyg/_wysiwyg.scss
+++ b/scss/components/wysiwyg/_wysiwyg.scss
@@ -36,26 +36,27 @@
   }
 
   h2 {
-    font-size: 1.8em;/* for barb. didn't want to change global line-height, etc*/
     @include dash-left-offset;
+    font-size: 1.8em;
   }
+
   h3 {
     font-size: 1.6em;
   }
-  }
+
 
 
   // Floated images
-  figure {
-    display: table;
-    margin-bottom: 30px;
+figure {
+  display: table;
+  margin-bottom: 30px;
 
-    &.align-right {
-      margin-left: 30px;
+  &.align-right {
+    margin-left: 30px;
     }
 
-    &.align-left {
-      margin-right: 30px;
+  &.align-left {
+    margin-right: 30px;
     }
   }
 
@@ -70,7 +71,7 @@
   figcaption {
     display: table-caption;
     caption-side: bottom;
-    color: color(ash);
+    color: color(stone);
     text-align: left;
   }
 
@@ -115,28 +116,31 @@
   }
 
 //Special styles for Barb to use
-h3.teal, h2.teal {
-  color: #017c92;
+  h3.teal,
+  h2.teal {
+    color: #017c92;
 }
 
-h2.cardinal, h3.cardinal {
-  color: #8c1515;
+   h2.cardinal,
+   h3.cardinal {
+     color: #8c1515;
 }
 
-div.well-insert {
-  background-color: #F9F6EF;
-  float: left;
-  clear: none;
-  width: 30%;
-  padding: 15px;
-  margin: 15px;
+  div.well-insert {
+    background-color: #F9F6EF;
+    float: left;
+    clear: none;
+    width: 30%;
+    padding: 15px;
+    margin: 15px;
 }
 
-div.well-insert-right {
-  background-color: #F9F6EF;
-  float: right;
-  clear: none;
-  width: 30%;
-  padding: 15px;
-  margin: 15px;
+  div.well-insert-right {
+    background-color: #F9F6EF;
+    float: right;
+    clear: none;
+    width: 30%;
+    padding: 15px;
+    margin: 15px;
+}
 }

--- a/scss/components/wysiwyg/_wysiwyg.scss
+++ b/scss/components/wysiwyg/_wysiwyg.scss
@@ -23,7 +23,7 @@
   }
 
   p + h2 {
-    margin-top: 50px;
+    margin-top: 25px;
   }
 
   blockquote + h1,
@@ -34,6 +34,16 @@
   blockquote + h6, {
     margin-top: modular-scale(0);
   }
+
+  @media only screen and (min-width: 576px) {
+  h2 {
+      font-size: 1.8em;/* for barb. didn't want to change global line-height, etc*/
+  }
+  h3 {
+    font-size: 1.6em;
+  }
+  }
+
 
   // Floated images
   figure {

--- a/scss/components/wysiwyg/_wysiwyg.scss
+++ b/scss/components/wysiwyg/_wysiwyg.scss
@@ -19,7 +19,7 @@
   }
 
   p {
-    margin-bottom: 30px;
+    margin-bottom: 1em;
   }
 
   p + h2 {
@@ -35,9 +35,9 @@
     margin-top: modular-scale(0);
   }
 
-  @media only screen and (min-width: 576px) {
   h2 {
-      font-size: 1.8em;/* for barb. didn't want to change global line-height, etc*/
+    font-size: 1.8em;/* for barb. didn't want to change global line-height, etc*/
+    @include dash-left-offset;
   }
   h3 {
     font-size: 1.6em;
@@ -114,4 +114,29 @@
     clear: both;
   }
 
+//Special styles for Barb to use
+h3.teal, h2.teal {
+  color: #017c92;
+}
+
+h2.cardinal, h3.cardinal {
+  color: #8c1515;
+}
+
+div.well-insert {
+  background-color: #F9F6EF;
+  float: left;
+  clear: none;
+  width: 30%;
+  padding: 15px;
+  margin: 15px;
+}
+
+div.well-insert-right {
+  background-color: #F9F6EF;
+  float: right;
+  clear: none;
+  width: 30%;
+  padding: 15px;
+  margin: 15px;
 }

--- a/scss/components/wysiwyg/_wysiwyg.scss
+++ b/scss/components/wysiwyg/_wysiwyg.scss
@@ -51,12 +51,12 @@
     display: table;
     margin-bottom: 30px;
 
-  &.align-right {
-    margin-left: 30px;
+    &.align-right {
+      margin-left: 30px;
     }
 
-  &.align-left {
-    margin-right: 30px;
+    &.align-left {
+      margin-right: 30px;
     }
   }
 
@@ -96,12 +96,12 @@
     width: 100%;
     min-width: 100%;
 
-      &.align-right {
-        margin-left: 0;
+    &.align-right {
+      margin-left: 0;
     }
 
-      &.align-left {
-        margin-right: 0;
+    &.align-left {
+      margin-right: 0;
     }
   }
 

--- a/scss/components/wysiwyg/_wysiwyg.scss
+++ b/scss/components/wysiwyg/_wysiwyg.scss
@@ -96,12 +96,12 @@
     width: 100%;
     min-width: 100%;
 
-    &.align-right {
-      margin-left: 0;
+      &.align-right {
+        margin-left: 0;
     }
 
-    &.align-left {
-      margin-right: 0;
+      &.align-left {
+        margin-right: 0;
     }
   }
 
@@ -123,7 +123,7 @@
 
   h2.cardinal,
   h3.cardinal {
-     color: #8c1515;
+    color: #8c1515;
 }
 
   div.well-insert {

--- a/scss/theme/stanford-news.scss
+++ b/scss/theme/stanford-news.scss
@@ -49,8 +49,8 @@ h1 {
 // Date field.
 .block--field-s-news-date {
   position: relative;
-  border-bottom: .5px solid color(ash);
-  border-top: .5px solid color(ash);
+  border-bottom: .5px solid color(stone);
+  border-top: .5px solid color(stone);
   padding: 10px;
   margin-top: 10px;
 

--- a/scss/theme/stanford-news.scss
+++ b/scss/theme/stanford-news.scss
@@ -167,7 +167,7 @@ h1 {
 }
 
 .section-news .field--body {
-    padding-bottom: 0px;
+  padding-bottom: 0;
 }
 
 // Layout spacing

--- a/scss/theme/stanford-news.scss
+++ b/scss/theme/stanford-news.scss
@@ -166,6 +166,10 @@ h1 {
   }
 }
 
+.section-news .field--body {
+    padding-bottom: 0px;
+}
+
 // Layout spacing
 .layout--basic {
   .field-p-wysiwyg {
@@ -250,7 +254,7 @@ figure.align-center .figure-container {
   }
 
   p {
-    color: color(ash);
+    color: color(stone);
   }
 
   h5,


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added in fixes mostly for accessibility and to accommodate WYSIWYG in various PTs.

# Needed By (Date)
- No urgency

# Urgency
- Not very.

# Steps to Test
FIRST: disable the CSS injector rules Fixes for Barbara" and "Text Re-Styling for Consistency and Accessibility" THEN
1. Add a header, list, or link to various PTs (for example, Deep Linking Hero banner or Links Banner). Check to make sure font is good color/is visible.
3. Next, add an h2 to a plain WYSIWYG field. Note that it has the red dash.
4. Go to the WYSIWYG and add one of the other styles (Teal H2) and verify that it looks OK.
5. Check paragraph padding on Earth Matters news items and verify that it looks OK.
6. Check paragraph padding on WYSIWYG PT and verify that it looks OK.
7. Look at social actions area on a news item. Note that there is a top and bottom border.


# Affected Projects or Products
- When this is pushed to production, the CSS injector rules "Fixes for Barbara" and "Text Re-Styling for Consistency and Accessibility" should be removed.

# Associated Issues and/or People
- Also related to EARTH-566 and EARTH-557

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)