### PR TITLE
EARTH-569: changed spacing on drop-down menu items

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -2315,7 +2315,7 @@
       color: #fff;
       display: block;
       font-size: 0.875em;
-      line-height: 30px;
+      line-height: 20px;
       letter-spacing: 0.15625em;
       padding: 1em 0;
       text-align: center;
@@ -2355,7 +2355,7 @@
       display: block; }
     .navigation__main-menu ul ul a {
       border-top: 0;
-      padding: 1em 1em; }
+      padding: 1.8em 1em; }
       .navigation__main-menu ul ul a:hover, .navigation__main-menu ul ul a:active, .navigation__main-menu ul ul a:focus {
         box-shadow: none; }
 

--- a/scss/components/navigation/_navigation.scss
+++ b/scss/components/navigation/_navigation.scss
@@ -57,7 +57,7 @@ $nav-active-item-shadow: inset 0 -3px 0 0 rgba(249, 176, 2, 1);
       color: color(white);
       display: block;
       font-size: em(14px);
-      line-height: 30px;
+      line-height: 20px;
       letter-spacing: em(2.5px);
       padding: 1em 0;
       text-align: center;
@@ -108,7 +108,7 @@ $nav-active-item-shadow: inset 0 -3px 0 0 rgba(249, 176, 2, 1);
 
     a {
       border-top: 0;
-      padding: 1em 1em;
+      padding: 1.8em 1em;
 
       @include on-event {
         box-shadow: none;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Reduce leading in wrapped text in the drop-down menu.

# Needed By (Date)
- No urgency

# Urgency
- Not terribly.

# Steps to Test

1. Look at the drop-down menu for Academics or About
2. Notice that the leading between Department & Programs or Working Professionals is reduced

# Affected Projects or Products
- No.

# Associated Issues and/or People
-EARTH-569

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)