### PR TITLE
EARTH-772: Remove duplicate h1 tags on page-title.

### DIFF
--- a/templates/content/page-title.html.twig
+++ b/templates/content/page-title.html.twig
@@ -1,0 +1,20 @@
+{#
+/**
+ * @file
+ * Theme override for page titles.
+ *
+ * Available variables:
+ * - title_attributes: HTML attributes for the page title element.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title: The page title, for use in the actual content.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ */
+#}
+
+{% if title %}
+  <div {{ attributes.addClass('block--page-title') }}>
+    {{ title }}
+  </div>
+{% endif %}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
-  Remove duplicate h1 tags on page-title.

# Needed By (Date)
- Wednesday March 28th

# Steps to Test

1. Check out this branch
2. Create a new content type
3. Create a new node of that content type
4. Review page title markup and ensure double nesting of h1s is no longer 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)