### PR TITLE
EARTH-688: adjusted size of svg icons on masonry blocks

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -2068,6 +2068,8 @@
   color: #D8D8D8;
   margin: 0 11px;
   padding: 15px 0; }
+  .masonry-block__footer i-svg {
+    width: 1em; }
 
 .masonry-block__social-link:hover svg use, .masonry-block__social-link:active svg use, .masonry-block__social-link:focus svg use {
   fill: #9c9d9e; }

--- a/scss/components/masonry-block/_masonry-block.scss
+++ b/scss/components/masonry-block/_masonry-block.scss
@@ -168,6 +168,10 @@
   color: color(smoke);
   margin: 0 11px;
   padding: 15px 0;
+
+  i-svg {
+    width: 1em;
+  }
 }
 
 .masonry-block__social-link {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adjust size of social media icons

# Needed By (Date)
- No urgency

# Steps to Test

1. Go to Earth Matters
2. Look at a skinny masonry block
3. Notice the social media footer and date on same line

# Affected Projects or Products
- Earth Matters

# Associated Issues and/or People
- Earth 713 should be done soon

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)