### PR TITLE
EARTH-755: new subsite navigation font size

### DIFF
--- a/css/layout/stanford-subsite.css
+++ b/css/layout/stanford-subsite.css
@@ -95,7 +95,6 @@
       #floating_sidebar__wrapper .menu li > a {
         color: #222328;
         padding: 16px;
-        font-size: font-size(16px);
         font-weight: 600;
         text-transform: uppercase; }
       #floating_sidebar__wrapper .menu li > a:hover,
@@ -121,6 +120,7 @@
         text-transform: uppercase;
         letter-spacing: 1px;
         font-weight: 600;
+        font-size: .75em;
         line-height: 1em;
         padding: 0.9375em 0.9375em;
         -webkit-transition: background 0.5s;

--- a/scss/layout/subsite/_floating-sidebar.scss
+++ b/scss/layout/subsite/_floating-sidebar.scss
@@ -57,7 +57,6 @@
       >  a {
           color: #222328;
           padding: 16px;
-          font-size: font-size(16px);
           font-weight: 600;
           text-transform: uppercase;
         }
@@ -93,6 +92,7 @@
           text-transform: uppercase;
           letter-spacing: 1px;
           font-weight: 600;
+          font-size: .75em;
           line-height: 1em;
           padding: em(15px) em(15px);
           -webkit-transition: background 0.5s; // Safari.


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
To make the subsite navigation items smaller than the subsite home link

# Needed By (Date)
- No rush

# Steps to Test

1. Open a subsite page (for example /inside-stanford-earth)
2. Look at the sidebar navigation links
3. Note they are smaller than the linked name to the subsite homepage (and should be same size as main nav items)

# Affected Projects or Products
- None, really.

# Associated Issues and/or People
- Request from Aaron Cole

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)