### PR TITLE
Earth 493 stamp styling

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -2041,6 +2041,11 @@
     @media only screen and (min-width: 768px) {
       .masonry-block.is-full-width .masonry-block__title {
         font-size: 32px; } }
+  .masonry-block.stamp a {
+    color: #fff; }
+    .masonry-block.stamp a.button {
+      border: 1px solid #fff;
+      width: 100%; }
 
 .masonry-block__title {
   font-size: 20px;

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -2041,11 +2041,6 @@
     @media only screen and (min-width: 768px) {
       .masonry-block.is-full-width .masonry-block__title {
         font-size: 32px; } }
-  .masonry-block.stamp a {
-    color: #fff; }
-    .masonry-block.stamp a.button {
-      border: 1px solid #fff;
-      width: 100%; }
 
 .masonry-block__title {
   font-size: 20px;
@@ -2094,6 +2089,11 @@
 
 .section-masonry-blocks {
   background-color: #dad7cb; }
+  .section-masonry-blocks.stamp a {
+    color: #fff; }
+    .section-masonry-blocks.stamp a.button {
+      border: 1px solid #fff;
+      width: 100%; }
 
 #toast-container > div.toast.toast-success,
 #toast-container > div.toast.toast-warning,

--- a/scss/components/masonry-block/_masonry-block.scss
+++ b/scss/components/masonry-block/_masonry-block.scss
@@ -136,6 +136,15 @@
       }
     }
   }
+  &.stamp {
+    a {
+      color: color(white);
+      &.button {
+        border: 1px solid color(white);
+        width: 100%;
+      }
+    }
+  }
 }
 
 .masonry-block__title {

--- a/scss/components/masonry-block/_masonry-block.scss
+++ b/scss/components/masonry-block/_masonry-block.scss
@@ -136,15 +136,6 @@
       }
     }
   }
-  &.stamp {
-    a {
-      color: color(white);
-      &.button {
-        border: 1px solid color(white);
-        width: 100%;
-      }
-    }
-  }
 }
 
 .masonry-block__title {
@@ -211,4 +202,13 @@
 
 .section-masonry-blocks {
   background-color: color(fog);
+  &.stamp {
+    a {
+      color: color(white);
+      &.button {
+        border: 1px solid color(white);
+        width: 100%;
+      }
+    }
+  }
 }


### PR DESCRIPTION
# READY FOR REVIEW/NOT READY
- (Edit the above to reflect status)

# Summary
- To give basic link styling to the Earth Matters masonry block stamps.

# Needed By (Date)
- When other EARTH-493 stuff is merged

# Steps to Test
1. Make a new stamp
2. Make two links, give one the class "button."
3. Check to make sure link is white and button border & text is white

# Affected Projects or Products
- Earth Matters

# Associated Issues and/or People
- EARTH 493
- Need to add button option to wysiwyg to use (EARTH-795)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)