### PR TITLE
EARTH-713: Changed color from ash or smoke to stone

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -2065,21 +2065,21 @@
 
 .masonry-block__footer {
   border-top: 1px solid #D8D8D8;
-  color: #D8D8D8;
+  color: #4d4f53;
   margin: 0 11px;
   padding: 15px 0; }
 
 .masonry-block__social-link:hover svg use, .masonry-block__social-link:active svg use, .masonry-block__social-link:focus svg use {
-  fill: #9c9d9e; }
-
-.masonry-block__social-link svg use {
   fill: #D8D8D8; }
 
+.masonry-block__social-link svg use {
+  fill: #4d4f53; }
+
 .masonry-block__date {
-  border-right: 1px solid #D8D8D8; }
+  border-right: 1px solid #9c9d9e; }
 
 .masonry-block__social-links {
-  border-right: 1px solid #D8D8D8; }
+  border-right: 1px solid #9c9d9e; }
 
 .masonry-block__arrow svg use {
   fill: #8c1515; }

--- a/scss/components/masonry-block/_masonry-block.scss
+++ b/scss/components/masonry-block/_masonry-block.scss
@@ -165,7 +165,7 @@
 
 .masonry-block__footer {
   border-top: 1px solid color(smoke);
-  color: color(smoke);
+  color: color(stone);
   margin: 0 11px;
   padding: 15px 0;
 }
@@ -173,21 +173,21 @@
 .masonry-block__social-link {
   @include on-event {
     svg use {
-      fill: color(ash);
+      fill: color(smoke);
     }
   }
 
   svg use {
-    fill: color(smoke);
+    fill: color(stone);
   }
 }
 
 .masonry-block__date {
-  border-right: 1px solid color(smoke);
+  border-right: 1px solid color(ash);
 }
 
 .masonry-block__social-links {
-  border-right: 1px solid color(smoke);
+  border-right: 1px solid color(ash);
 }
 
 .masonry-block__arrow svg {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- To make social media icons on EM masonry blocks more visible/accessible

# Needed By (Date)
- No rush

# Urgency
- Not.

# Steps to Test

1. Go to Earth Matters
2. Go to masonry block with a white background
3. Check that the social media icons and date are #4d4f53 (dark grey)

# Affected Projects or Products
- Earth Matters

# Associated Issues and/or People
- Earth-713

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)