### PR TITLE
EARTH-735: Updated wyswiyg styles for 1/4 size repsonsive image.

### DIFF
--- a/css/wysiwyg/wysiwyg.css
+++ b/css/wysiwyg/wysiwyg.css
@@ -6,6 +6,9 @@ body {
   padding: 0;
   display: block; }
 
+img[data-responsive-image-style="small_scaled"] {
+  width: 25%; }
+
 img[data-responsive-image-style="portrait"],
 img[data-responsive-image-style="landscape"] {
   width: 48%; }

--- a/scss/wysiwyg/wysiwyg.scss
+++ b/scss/wysiwyg/wysiwyg.scss
@@ -12,6 +12,11 @@ body {
 }
 
 // Fixes for image styles so they kind of look like what we want.
+img[data-responsive-image-style="small_scaled"] {
+  width: 25%;
+}
+
+// Fixes for image styles so they kind of look like what we want.
 img[data-responsive-image-style="portrait"],
 img[data-responsive-image-style="landscape"] {
   width: 48%;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adds some CSS to make the 1/4 size image embed in to the wysiwyg a little nicer.

# Needed By (Date)
- End of next sprint

# Urgency
- Low

# Steps to Test

1. Check out branch EARTH-735 of SE3_BLT and this
2. Run a `blt sync:refresh` or `drush cim` and clear cache
2b. Really really clear caches. Wyswiyg style gets stuck.
3. Validate that you can place a smaller size image in to the wysiwyg and that it doesn't appear as 100% of the actual size.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)