### PR TITLE
EARTH-646: changed z-index of title

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -943,7 +943,7 @@
   z-index: 2; }
   .drop-cap-title__name > div {
     position: relative;
-    z-index: 3; }
+    z-index: 2; }
 
 .drop-cap-title__drop-cap {
   position: absolute;

--- a/scss/components/drop-cap/_drop-cap.scss
+++ b/scss/components/drop-cap/_drop-cap.scss
@@ -20,7 +20,7 @@
 
   > div {
     position: relative;
-    z-index: 3;
+    z-index: 2;
   }
 }
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- The title on shorter heading pages was floating above the menu on mobile. This fixes the z-index so that doesn't happen.

# Needed By (Date)
- No date

# Urgency
- How critical is this PR? Not very, but it is a nice improvement.

# Steps to Test

1. Go to Media Mentions (news-events/media-mentions) on a phone or small browser window
2. Click on the hamburger
3. Observe that the title is no longer floating on top of the menu.

# Affected Projects or Products
- Earth website

# Associated Issues and/or People
- EARTH-646

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)