### PR TITLE
Earth 749 photo caption margin

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -1599,7 +1599,7 @@
 
 .hero-banner__footer {
   text-align: center;
-  margin-top: -60px; }
+  margin-top: 0px; }
   @media only screen and (max-width: 575px) {
     .hero-banner__footer {
       padding: 1em calc(((50% /12) * 0) + 15px); }
@@ -1644,7 +1644,7 @@
         display: block; } }
   @media only screen and (min-width: 768px) {
     .hero-banner__footer {
-      text-align: right; } }
+      text-align: left; } }
 
 .hero-banner.component-centered-container-margins.has-video .hero-banner__container {
   border: 0; }

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -1599,7 +1599,7 @@
 
 .hero-banner__footer {
   text-align: center;
-  margin-top: 0px; }
+  margin-top: 0; }
   @media only screen and (max-width: 575px) {
     .hero-banner__footer {
       padding: 1em calc(((50% /12) * 0) + 15px); }

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -943,7 +943,7 @@
   z-index: 2; }
   .drop-cap-title__name > div {
     position: relative;
-    z-index: 3; }
+    z-index: 2; }
 
 .drop-cap-title__drop-cap {
   position: absolute;

--- a/scss/components/drop-cap/_drop-cap.scss
+++ b/scss/components/drop-cap/_drop-cap.scss
@@ -20,7 +20,7 @@
 
   > div {
     position: relative;
-    z-index: 3;
+    z-index: 2;
   }
 }
 

--- a/scss/components/hero-banner/_hero-banner.scss
+++ b/scss/components/hero-banner/_hero-banner.scss
@@ -88,7 +88,7 @@ $hero-max-width-lg: 1500px;
   }
 
   text-align: center;
-  margin-top: 0px;
+  margin-top: 0;
 }
 
 .hero-banner.component-centered-container-margins.has-video {

--- a/scss/components/hero-banner/_hero-banner.scss
+++ b/scss/components/hero-banner/_hero-banner.scss
@@ -84,11 +84,11 @@ $hero-max-width-lg: 1500px;
 .hero-banner__footer {
   @include responsive-container($default-container);
   @include grid-media($media-md) {
-    text-align: right;
+    text-align: left;
   }
 
   text-align: center;
-  margin-top: -60px;
+  margin-top: 0px;
 }
 
 .hero-banner.component-centered-container-margins.has-video {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- For some reason there was a -60px photo credit margin in the Hero Banner footer. This PR removes that -60px and also properly changes the alignment on the caption to left.

# Needed By (Date)
- No urgency. There is a CSS injector rule currently fixing this.

# Urgency
- Not very.

# Steps to Test

1. Disable the CSS injector caption rule called "Photo Caption"
2. Go to page with a photo caption such as news/getting-zero-deforestation
3. Check to make sure the photo caption is visible at all screen sizes.

# Affected Projects or Products
- Nope

# Associated Issues and/or People
- EARTH-749
- CSS injector rule for .hero-banner__footer can be trimmed after this (leave other two rules.)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)