### PR TITLE
adding patterns directory to gruntfile and fixing double filmstrip

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,7 +30,7 @@ module.exports = function(grunt) {
         }
       },
       css: {
-        files: ['scss/**/*.scss'],
+        files: ['scss/**/*.scss', 'patterns/**/*.scss'],
         tasks: ['sass'],
         options: {
           interrupt: true

--- a/patterns/molecules/filmstrip/css/filmstrip.component.css
+++ b/patterns/molecules/filmstrip/css/filmstrip.component.css
@@ -67,13 +67,6 @@
       float: left;
       margin-left: 30px;
       max-width: none; } }
-  @media only screen and (min-width: 1024px) {
-    .filmstrip.is-double .film-card {
-      width: calc(33.3333333333% - 40px);
-      float: left;
-      margin-left: 30px; }
-      .filmstrip.is-double .film-card:nth-child(4n) {
-        clear: left; } }
   .filmstrip.is-double .film-card .film-card__thumbnail {
     position: relative;
     width: 100%;

--- a/patterns/molecules/filmstrip/scss/filmstrip.component.scss
+++ b/patterns/molecules/filmstrip/scss/filmstrip.component.scss
@@ -101,13 +101,6 @@
         max-width: none;
       }
 
-      @include grid-media($media-lg) {
-        @include grid-column(4, $callout-filmstrip-flexible);
-        &:nth-child(4n) {
-          clear: left;
-        }
-      }
-
       .film-card__thumbnail {
         @include image-gradient($image-gradient-bg-color: rgba(0, 0, 0, 0.75));
         width: 100%;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adding patterns folder to gruntfile so nice css is made!

# Needed By (Date)
-soonish!

# Urgency
- Not terribly urgent.

# Steps to Test

1. run grunt devmode
2. Edit scss in /patterns/
3. notice that css is produced
4. and then go to /research/discovering-our-planet and notice that the double filmstrips near the bottom wrap properly.

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- EARTH-821 and EARTH-813 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)