### PR TITLE
EARTH 797: tested earth stamp styling

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -2067,9 +2067,6 @@
   text-align: center;
   font-size: .8em; }
 
-.stamp h3.masonry-block__title {
-  display: none; }
-
 .stamp .masonry-block__description {
   font-size: .8em; }
 

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -2045,6 +2045,34 @@
 .stamp.stamp-3 {
   background: #017c92; }
 
+.stamp a {
+  text-align: center;
+  width: 100%;
+  color: #fff; }
+  .stamp a:hover {
+    color: #f9b002; }
+
+.stamp .button {
+  margin-bottom: 10px;
+  font-size: 1.6em;
+  border-color: #fff;
+  width: 100%;
+  text-align: center; }
+  .stamp .button:hover {
+    background-color: #f9b002;
+    color: #fff; }
+
+.stamp .about {
+  width: 100%;
+  text-align: center;
+  font-size: .8em; }
+
+.stamp h3.masonry-block__title {
+  display: none; }
+
+.stamp .masonry-block__description {
+  font-size: .8em; }
+
 @media only screen and (min-width: 768px) {
   .js .stamp {
     position: absolute; }

--- a/patterns/molecules/masonry-block/masonry-block.html.twig
+++ b/patterns/molecules/masonry-block/masonry-block.html.twig
@@ -75,15 +75,13 @@ image|get_img_src is not empty ? random(['has-image-right','has-image-left'])
     {% endif %}
     <div class="masonry-block__header">
       {% if title is not empty %}
-        <h3 class="masonry-block__title">
-          {% if variants.stamp is empty or variants.stamp == "0" %}
+        {% if variants.stamp is empty or variants.stamp == "0" %}
+          <h3 class="masonry-block__title">
           <a class="masonry-block__link" href="{{ link|render|striptags|trim|raw }}">
-          {% endif %}
-          {{ title }}
-          {% if variants.stamp is empty or variants.stamp == "0" %}
+            {{ title }}
           </a>
-          {% endif %}
-        </h3>
+          </h3>
+        {% endif %}
       {% endif %}
       {% if description is not empty %}
         <span class="masonry-block__description">{{ description }}</span>

--- a/scss/components/masonry-block/_masonry-block.scss
+++ b/scss/components/masonry-block/_masonry-block.scss
@@ -174,10 +174,6 @@
     font-size: .8em;
   }
 
-  h3.masonry-block__title {
-    display: none;
-  }
-
   .masonry-block__description {
     font-size: .8em;
   }

--- a/scss/components/masonry-block/_masonry-block.scss
+++ b/scss/components/masonry-block/_masonry-block.scss
@@ -144,6 +144,44 @@
   &.stamp-3 {
     background: color(action);
   }
+
+  a {
+    text-align: center;
+    width: 100%;
+    color: color(white);
+
+    &:hover {
+      color: color(emphasis);
+    }
+  }
+
+  .button {
+    margin-bottom: 10px;
+    font-size: 1.6em;
+    border-color: color(white);
+    width: 100%;
+    text-align: center;
+
+    &:hover {
+      background-color: color(emphasis);
+      color: color(white);
+    }
+  }
+
+  .about {
+    width: 100%;
+    text-align: center;
+    font-size: .8em;
+  }
+
+  h3.masonry-block__title {
+    display: none;
+  }
+
+  .masonry-block__description {
+    font-size: .8em;
+  }
+
 }
 
 // JS Enabled only.


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- To make the masonry stamp styling work without css injector

# Needed By (Date)
- No urgency. CSS injector is doing its job.

# Urgency
- Not very

# Steps to Test

1. Go look at the stamp on Earth Matters
2. Disable the CSS injector rule called "Stamp" & clear cache
3. Go look at the stamp on Earth Matters 
4. Make sure it looks the same!

# Affected Projects or Products
- Earth Matters

# Associated Issues and/or People
- EARTH 797

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)