### PR TITLE
Earth 718: changed selector for dropcap

### DIFF
--- a/css/theme/stanford-news.css
+++ b/css/theme/stanford-news.css
@@ -403,12 +403,12 @@ figure.align-center .figure-container {
     .field-s-news-source {
       margin-left: 110px; } }
 
-.field-s-news-rich-content .field-p-wysiwyg:nth-of-type(1) > p:first-of-type::first-line {
+.field-s-news-rich-content .ptype-stanford-wysiwyg:first-of-type .field-p-wysiwyg > p:first-of-type::first-line {
   position: relative;
   font-size: 1em;
   letter-spacing: normal; }
 
-.field-s-news-rich-content .field-p-wysiwyg:nth-of-type(1) > p:first-child::first-letter {
+.field-s-news-rich-content .ptype-stanford-wysiwyg:first-of-type .field-p-wysiwyg > p:first-child::first-letter {
   letter-spacing: 0;
   font-size: 3em;
   font-weight: bold;

--- a/scss/theme/stanford-news.scss
+++ b/scss/theme/stanford-news.scss
@@ -335,7 +335,7 @@ figure.align-center .figure-container {
 }
 
 
-.field-s-news-rich-content .field-p-wysiwyg:nth-of-type(1) {
+.field-s-news-rich-content .ptype-stanford-wysiwyg:first-of-type .field-p-wysiwyg {
   // Drop Cap
   > p:first-of-type::first-line {
     position: relative;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- So that only one dropcap appears, even when multiple wysiwyg pts are used

# Needed By (Date)
- No urgency

# Urgency
- Not very

# Steps to Test

1. Go to /news/new-techniques-removing-carbon-atmosphere
2. Look at the paragraph with the start "That" that is under the postcard. Check that it has no drop cap.
3. Also check that the first paragraph DOES have a dropcap!

# Affected Projects or Products
- Earth Matters

# Associated Issues and/or People
-EARTH 718

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)