### PR TITLE
EARTH-286: Voiceover fixes for tall filmstrip

### DIFF
--- a/patterns/organisms/section-tall-filmstrip/js/section-tall-filmstrip.js
+++ b/patterns/organisms/section-tall-filmstrip/js/section-tall-filmstrip.js
@@ -4,7 +4,25 @@
   $(window).bind('load', function () {
     $(".js-expandable-container__toggle").unbind('click').bind('click', function(e) { // expandable card
       $(this).parent(".js-expandable-container").addClass('is-open');
-      $(this).parent(".js-expandable-container").find(".film-card__link").eq(3).focus();
+      $(this).parent(".js-expandable-container")
+        .parent()
+        .find(".aria-alert")
+        .toggleClass('hidden')
+        .attr("role", "alert")
+        .fadeOut(1);
+
+        $(this).parent(".js-expandable-container")
+          .parent()
+          .find(".aria-alert")
+          .promise()
+          .done(function() {
+            $(this).parents(".js-expandable-container")
+              .find(".film-card__link")
+              .eq(4)
+              .focus()
+              .attr("role", "alert");
+          });
+
       // Must be attached to anchor element to prevent bubbling.
       e.preventDefault();
       e.stopPropagation();

--- a/patterns/organisms/section-tall-filmstrip/js/section-tall-filmstrip.js
+++ b/patterns/organisms/section-tall-filmstrip/js/section-tall-filmstrip.js
@@ -9,7 +9,7 @@
         .find(".aria-alert")
         .toggleClass('hidden')
         .attr("role", "alert")
-        .fadeOut(1);
+        .fadeOut(100);
 
         $(this).parent(".js-expandable-container")
           .parent()

--- a/patterns/organisms/section-tall-filmstrip/section-tall-filmstrip.html.twig
+++ b/patterns/organisms/section-tall-filmstrip/section-tall-filmstrip.html.twig
@@ -29,6 +29,7 @@
       <a href="#" class="expandable-container__toggle js-expandable-container__toggle">
         <span class="visually-hidden">Show More</span><span class="expandable-container__open"><svg class="i-svg i-svg--plus" role="img"><title>{{ 'Expand for more items'|t }}</title><use xlink:href="#i-plus" xmlns:xlink="http://www.w3.org/1999/xlink"></use></svg></span>
       </a>
+      <span class="aria-alert hidden">Item list expanded. There are now {{ field_count(items) }} in this list. Selecting item 5</span>
     {% endif %}
   </div>
 </div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Changes behaviour for those using keyboard controls
- Should announce the expansion of the list and selected item

# Needed By (Date)
- End of sprint

# Urgency
- Low

# Steps to Test

1. Check out this branch
2. Clear caches
3. Navigate to /patterns/section_tall_filmstrip
4. Turn on voiceover or chrome vox
5. Tab in to the expand button for the filmstrip
6. Press enter and evaluate the experience for spoken feedback and focused element

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)