### PR TITLE
EARTH-677: making video and caption less wide when centered margin va…

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -1659,6 +1659,18 @@
 .hero-banner.component-centered-container-margins.has-video .hero-banner__container {
   border: 0; }
 
+@media only screen and (min-width: 768px) {
+  .hero-banner.component-centered-container-margins.has-video .video {
+    padding-right: 110px;
+    padding-left: 110px; } }
+
+@media only screen and (min-width: 576px) {
+  .hero-banner.component-centered-container-margins.has-video .video {
+    padding: 0 80px; } }
+
+.hero-banner.component-centered-container-margins.has-video .hero-banner__inner .hero-banner__container {
+  margin: 0 80px; }
+
 .hero-banner.has-video .hero-banner__inner {
   display: none; }
   @media only screen and (min-width: 768px) {

--- a/scss/components/hero-banner/_hero-banner.scss
+++ b/scss/components/hero-banner/_hero-banner.scss
@@ -105,8 +105,8 @@ $hero-max-width-lg: 1500px;
     @include grid-media($media-sm) {
       padding: 0 80px;
     }
-    
   }
+
   .hero-banner__inner .hero-banner__container {
     margin: 0 80px;
   }

--- a/scss/components/hero-banner/_hero-banner.scss
+++ b/scss/components/hero-banner/_hero-banner.scss
@@ -95,6 +95,19 @@ $hero-max-width-lg: 1500px;
   .hero-banner__container {
     border: 0;
   }
+
+  .video {
+    @include grid-media($media-md) {
+      padding-right: 110px;
+      padding-left: 110px;
+    }
+    @include grid-media($media-sm) {
+      padding: 0 80px;
+    }
+  }
+  .hero-banner__inner .hero-banner__container {
+    margin: 0 80px;
+  }
 }
 
 .hero-banner.has-video {

--- a/scss/components/hero-banner/_hero-banner.scss
+++ b/scss/components/hero-banner/_hero-banner.scss
@@ -101,9 +101,11 @@ $hero-max-width-lg: 1500px;
       padding-right: 110px;
       padding-left: 110px;
     }
+
     @include grid-media($media-sm) {
       padding: 0 80px;
     }
+    
   }
   .hero-banner__inner .hero-banner__container {
     margin: 0 80px;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Making the Video PT have a smaller option (different than full-width)

# Needed By (Date)
- End of Sprint

# Urgency
- Not very

# Steps to Test

1. Go to a page that has a video where there is a videoPT placed with the centered with margins variant chosen, for example: news/understanding-kilauea-different-flavor-volcano
2. Check that the video has the margins of the text, or even smaller
3. Check that the title/caption is good
4. Test it on mobile
5. Make sure it doesn't affect any hero video banners

# Affected Projects or Products
- Video Hero banners

# Associated Issues and/or People
- EARTH-677

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)…riant chosen