### PR TITLE
EARTH-648: Video player title updates

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -1671,11 +1671,37 @@
 .hero-banner.component-centered-container-margins.has-video .hero-banner__inner .hero-banner__container {
   margin: 0 80px; }
 
-.hero-banner.has-video .hero-banner__inner {
-  display: none; }
-  @media only screen and (min-width: 768px) {
-    .hero-banner.has-video .hero-banner__inner {
-      display: block; } }
+@media only screen and (max-width: 767px) {
+  .hero-banner.has-video .hero-banner__inner,
+  .hero-banner.has-video .hero-banner__container,
+  .hero-banner.has-video .hero-banner__header,
+  .hero-banner.has-video .hero-banner__hgroup {
+    position: relative;
+    width: 100%;
+    text-align: left;
+    color: #4d4f53;
+    text-shadow: none;
+    height: auto;
+    min-height: 0;
+    margin: 0;
+    padding: 0;
+    clear: both;
+    float: none;
+    top: 0;
+    bottom: auto;
+    -webkit-transform: translate(0, 0);
+    -ms-transform: translate(0, 0);
+    transform: translate(0, 0);
+    left: 0; } }
+
+@media only screen and (max-width: 767px) {
+  .hero-banner.has-video .hero-banner__inner .hero-banner__hgroup,
+  .hero-banner.has-video .hero-banner__container .hero-banner__hgroup,
+  .hero-banner.has-video .hero-banner__header .hero-banner__hgroup,
+  .hero-banner.has-video .hero-banner__hgroup .hero-banner__hgroup {
+    width: 80%;
+    left: 10%;
+    text-align: center; } }
 
 .block--lockup__site-name-and-slogan, .block--lockup__site-slogan {
   border: 0;

--- a/patterns/molecules/hero-banner/hero-banner.ui_patterns.yml
+++ b/patterns/molecules/hero-banner/hero-banner.ui_patterns.yml
@@ -9,8 +9,8 @@ hero_banner:
       description: "Center the component in a responsive container"
       default: 0
       options:
-        true: "Centered"
         0: "Normal"
+        1: "Centered"
     has_tint:
       label: "Has background tinting"
       description: "Slight shade over background image"

--- a/patterns/molecules/hero-banner/hero-banner.ui_patterns.yml
+++ b/patterns/molecules/hero-banner/hero-banner.ui_patterns.yml
@@ -73,4 +73,6 @@ hero_banner:
         css:
           component:
             css/hero-banner.component.css: {}
+        js:
+          js/hero-banner.js: {}
   use: "@stanford_components/molecules/hero-banner/hero-banner.html.twig"

--- a/patterns/molecules/hero-banner/js/hero-banner.js
+++ b/patterns/molecules/hero-banner/js/hero-banner.js
@@ -40,7 +40,8 @@ function onYouTubeIframeAPIReady() {
 /**
  * When the youtube players are ready to be acted on.
  *
- * @param  {[type]} event [description]
+ * @param  object event
+ *  Object from youtube api with event information.
  */
 function onPlayerReady(event) {
   // console.log(event);
@@ -49,7 +50,7 @@ function onPlayerReady(event) {
 /**
  * When a youtube video state has been changed.
  *
- * @param  {[type]} event
+ * @param object event
  * event.data
  *   -1 unstarted
  *    0 ended
@@ -75,27 +76,35 @@ function onPlayerStateChange(event) {
 }
 
 /**
- * [matson_hero_banner_get_target_title description]
- * @param  {[type]} target [description]
- * @return {[type]}        [description]
+ * Matson_hero_banner_get_target_title.
+ *
+ * @param object target
+ *   DOM Object to act upon.
+ *
+ * @return Object
+ *   Jquery object containing the hero-banner__inner text container.
  */
 function matson_hero_banner_get_target_title(target) {
   return jQuery(target).parents(".hero-banner").find('.hero-banner__inner');
 }
 
 /**
- * [matson_hero_banner_hide_video_title description]
- * @param  {[type]} target [description]
- * @return {[type]}        [description]
+ * Matson_hero_banner_hide_video_title.
+ *
+ * @param object target
+ *   Jquery object to run function on.
  */
 function matson_hero_banner_hide_video_title(target) {
-  target.fadeOut(500);
+  if (window.innerWidth > 767) {
+    target.fadeOut(500);
+  }
 }
 
 /**
- * [matson_hero_banner_show_video_title description]
- * @param  {[type]} target [description]
- * @return {[type]}        [description]
+ * Matson_hero_banner_show_video_title.
+ *
+ * @param object target
+ *   Jquery object to run function on.
  */
 function matson_hero_banner_show_video_title(target) {
   target.fadeIn(500);

--- a/patterns/molecules/hero-banner/js/hero-banner.js
+++ b/patterns/molecules/hero-banner/js/hero-banner.js
@@ -1,0 +1,7 @@
+var tag = document.createElement('script');
+tag.id = 'youtube-iframe-api';
+tag.src = 'https://www.youtube.com/iframe_api';
+var firstScriptTag = document.getElementsByTagName('script')[0];
+firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+
+alert("hey");

--- a/patterns/molecules/hero-banner/js/hero-banner.js
+++ b/patterns/molecules/hero-banner/js/hero-banner.js
@@ -1,7 +1,102 @@
-var tag = document.createElement('script');
-tag.id = 'youtube-iframe-api';
-tag.src = 'https://www.youtube.com/iframe_api';
-var firstScriptTag = document.getElementsByTagName('script')[0];
-firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+//
+// Youtube iframe events api handling.
+//
+(function (Drupal, $, window) {
 
-alert("hey");
+  Drupal.behaviors.matson_hero_banner = {
+    attach: function (context, settings) {
+      var tag = document.createElement('script');
+      tag.id = 'youtube-iframe-api';
+      tag.src = 'https://www.youtube.com/iframe_api';
+      var firstScriptTag = document.getElementsByTagName('script')[0];
+      firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+    }
+  }
+
+} (Drupal, jQuery, this));
+
+// Set up the youtube event callbacks by starting with variable storage.
+var player;
+
+/**
+ * YouTube iframe event api ready callback.
+ *
+ * @return {[type]} [description]
+ */
+function onYouTubeIframeAPIReady() {
+  jQuery(".hero-banner").each(function(i, v) {
+    var videoId = jQuery(v).attr('id') + "-iframe";
+    jQuery(v).find('iframe').attr("id", videoId);
+
+    player = new YT.Player(videoId, {
+      events: {
+        'onReady': onPlayerReady,
+        'onStateChange': onPlayerStateChange
+      }
+    });
+  });
+}
+
+/**
+ * When the youtube players are ready to be acted on.
+ *
+ * @param  {[type]} event [description]
+ */
+function onPlayerReady(event) {
+  // console.log(event);
+}
+
+/**
+ * When a youtube video state has been changed.
+ *
+ * @param  {[type]} event
+ * event.data
+ *   -1 unstarted
+ *    0 ended
+ *    1 playing
+ *    2 paused
+ *    3 buffering
+ *    5 video cued
+ */
+function onPlayerStateChange(event) {
+  var status = event.data;
+  var target = event.target.a;
+  var target_title = matson_hero_banner_get_target_title(target);
+
+  // If the video is playing hide the title.
+  if (status == 1) {
+    matson_hero_banner_hide_video_title(target_title);
+  }
+
+  // If the video has ended or is paused show the title.
+  if (status == 0 || status == 2) {
+    matson_hero_banner_show_video_title(target_title);
+  }
+}
+
+/**
+ * [matson_hero_banner_get_target_title description]
+ * @param  {[type]} target [description]
+ * @return {[type]}        [description]
+ */
+function matson_hero_banner_get_target_title(target) {
+  return jQuery(target).parents(".hero-banner").find('.hero-banner__inner');
+}
+
+/**
+ * [matson_hero_banner_hide_video_title description]
+ * @param  {[type]} target [description]
+ * @return {[type]}        [description]
+ */
+function matson_hero_banner_hide_video_title(target) {
+  target.fadeOut(500);
+}
+
+/**
+ * [matson_hero_banner_show_video_title description]
+ * @param  {[type]} target [description]
+ * @return {[type]}        [description]
+ */
+function matson_hero_banner_show_video_title(target) {
+  target.fadeIn(500);
+}

--- a/scss/components/hero-banner/_hero-banner.scss
+++ b/scss/components/hero-banner/_hero-banner.scss
@@ -113,11 +113,35 @@ $hero-max-width-lg: 1500px;
 }
 
 .hero-banner.has-video {
-  .hero-banner__inner {
-    display: none;
-
-    @include grid-media($media-md) {
-      display: block;
+  .hero-banner__inner,
+  .hero-banner__container,
+  .hero-banner__header,
+  .hero-banner__hgroup {
+    @include grid-media($media-sm-max) {
+      position: relative;
+      width: 100%;
+      text-align: left;
+      color: color(stone);
+      text-shadow: none;
+      height: auto;
+      min-height: 0;
+      margin: 0;
+      padding: 0;
+      clear: both;
+      float: none;
+      top: 0;
+      bottom: auto;
+      -webkit-transform: translate(0, 0);
+      -ms-transform: translate(0, 0);
+      transform: translate(0, 0);
+      left: 0;
+    }
+    .hero-banner__hgroup {
+      @include grid-media($media-sm-max) {
+        width: 80%;
+        left: 10%;
+        text-align: center;
+      }
     }
   }
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adds better handling for the title overlay when the hero banner is a video

# Needed By (Date)
- Sometime next sprint

# Urgency
- Not sure.

# Steps to Test

1. Check out this branch and EARTH-648 of stanford_paragraph_types
2. Clear all caches. Really really clear all caches.
3. Review the home page on mobile for placement of the title below the video 
4. Review the home page on desktop for placement of the title over the video
5. Play the video to see the title fade out
6. Pause the video to see the title fade back in
7. Create a second and third video on the page
8. Test to see that the titles align below the video with other content on the page
9. Test to see that the titles independently fade in and out as each video is playing

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)