### PR TITLE
SITES-979: Update to twig_tweaks 2.0

### DIFF
--- a/patterns/molecules/calendar-block/calendar-block.html.twig
+++ b/patterns/molecules/calendar-block/calendar-block.html.twig
@@ -6,7 +6,7 @@
 #}
 {% set attributes = attributes.addClass("calendar-block") %}
 <div{{ attributes }}>
-  {{ link|openlink({class:"calendar-block__action", "aria-label": title|render|striptags|preg_replace(":", "") ~ '. on '|t ~ month ~ ' ' ~ day}) }}
+  {{ link|openlink({class:"calendar-block__action", "aria-label": title|render|striptags|preg_replace("/:/", "") ~ '. on '|t ~ month ~ ' ' ~ day}) }}
     <div class="calendar-block__date">
       <span class="calendar-block__day">{{ day }}</span>
       <span class="calendar-block__month">{{ month }}</span>

--- a/patterns/molecules/masonry-block/masonry-block.html.twig
+++ b/patterns/molecules/masonry-block/masonry-block.html.twig
@@ -106,7 +106,7 @@ image|get_img_src is not empty ? random(['has-image-right','has-image-left'])
               <a class='masonry-block__social-link masonry-block--facebook facebook-popup' aria-label="{{ 'Share on Facebook'|t }}" title="{{ 'Share on facebook'|t }}" href="https://www.facebook.com/sharer/sharer.php?u={{ get_tag_attribute(link|openlink|render, "a", "href") }}"><svg class="i-svg" role="img"><title>{{ 'Facebook'|t }}</title><use xlink:href="#i-fb" xmlns:xlink="http://www.w3.org/1999/xlink"></use></svg></a>
             </span>
 
-            {{ link|openlink({'aria-label': "Navigate to "|t ~ title|render|striptags|preg_replace(":", "") }) }}<span class="masonry-block__arrow"><svg class="i-svg i-svg--arrow-right" role="img"><title>{{ 'Navigate to item'|t }}</title><use xlink:href="#i-arrow" xmlns:xlink="http://www.w3.org/1999/xlink"></use></svg></span>{{ link|closelink }}
+            {{ link|openlink({'aria-label': "Navigate to "|t ~ title|render|striptags|preg_replace("/:/", "") }) }}<span class="masonry-block__arrow"><svg class="i-svg i-svg--arrow-right" role="img"><title>{{ 'Navigate to item'|t }}</title><use xlink:href="#i-arrow" xmlns:xlink="http://www.w3.org/1999/xlink"></use></svg></span>{{ link|closelink }}
           </div>
         {% endif %}
         {% endif %}

--- a/patterns/molecules/photo-social/photo-social.html.twig
+++ b/patterns/molecules/photo-social/photo-social.html.twig
@@ -5,7 +5,7 @@
  */
 #}
 {% if title is not empty %}
-  {% set arialabel = title|render|striptags|preg_replace(":", "") %}
+  {% set arialabel = title|render|striptags|preg_replace("/:/", "") %}
 {% else %}
 {% set arialabel = "Share photo"|t %}
 {% endif %}

--- a/patterns/molecules/postcard/postcard.html.twig
+++ b/patterns/molecules/postcard/postcard.html.twig
@@ -18,7 +18,7 @@
         {{ text }}
 
         {% if linkurl|openlink %}
-          {{ linkurl|openlink({class:'postcard__more', 'aria-label': "Read more about "|t ~ title|render|striptags|preg_replace(":", "") }) }}
+          {{ linkurl|openlink({class:'postcard__more', 'aria-label': "Read more about "|t ~ title|render|striptags|preg_replace("/:/", "") }) }}
             <svg class="i-svg i-svg--arrow-right" role="img">
               <title>{{ 'Navigate to item'|t }}</title>
               <use xlink:href="#i-arrow" xmlns:xlink="http://www.w3.org/1999/xlink"></use>

--- a/patterns/molecules/social-card/social-card.html.twig
+++ b/patterns/molecules/social-card/social-card.html.twig
@@ -4,7 +4,7 @@
  * Social Card pattern.
  */
 #}
-{% set arialabel = description|render|striptags|preg_replace(":", "") %}
+{% set arialabel = description|render|striptags|preg_replace("/:/", "") %}
 <div{{ attributes.addClass('social-card') }}>
   <div class="social-card__content">
     {{ handle_link|openlink({class: "social-card__name", 'aria-label': arialabel}) }}

--- a/templates/components/global-footer/global-footer.html.twig
+++ b/templates/components/global-footer/global-footer.html.twig
@@ -8,7 +8,7 @@
 <footer id="footer__container">
   <section class="contact-footer" style="background-image:url('{{ base_path ~ directory }}/img/optimized/footer-bg.jpg')";>
     <div class="contact-footer__brand">
-      {{ drupal_block('matson_branding')|render|preg_replace("block\-matson\-branding", "footer__block-matson-branding")|raw }}
+      {{ drupal_block('matson_branding')|render|preg_replace("/(block-matson-branding)/", "footer__block-matson-branding")|raw }}
     </div>
     <div class="contact-footer__social">
       <h2>{{ 'Join us on Social Media'|trans }}</h2>

--- a/templates/html.html.twig
+++ b/templates/html.html.twig
@@ -32,7 +32,7 @@
 #}
 <!DOCTYPE html>
 {% if ie_enabled_versions.ie8 %}
-  {{- attach_library('stanford_basic/ie8') }}
+  {{ attach_library('stanford_basic/ie8') }}
 {% endif %}
 {% if ie_enabled_versions.ie9 or ie_enabled_versions.ie8 %}
   <!--[if lt IE 7]>     <html{{ html_attributes.addClass('no-js', 'lt-ie9', 'lt-ie8', 'lt-ie7') }}><![endif]-->


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixes up preg_replace syntax for twig_tweaks 2.0

# Needed By (Date)
- Before EARTH-979 is merged in to SE3_BLT

# Urgency
- Low

# Steps to Test

1. Check out this branch on a current site
2. Enable the display of errors in the UI if you haven't already
3. Clear caches and navigate around a few pages on the front end.
4. Validate no PHP fatal errors or other twig related errors pop up.
5. Update the twig_tweaks module to 2.x and repeat step 4.

# Associated Issues and/or People
- EARTH-979

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)