### PR TITLE
Earth 954 sponsor events

### DIFF
--- a/css/layout/stanford-subsite.css
+++ b/css/layout/stanford-subsite.css
@@ -592,44 +592,51 @@
     margin-right: -30px;
     width: calc(100% + 60px); } }
 
-.section-feature-blocks {
+.section-feature-blocks.component-centered-container {
   margin-bottom: 24px; }
   @media only screen and (min-width: 768px) {
-    .section-feature-blocks {
+    .section-feature-blocks.component-centered-container {
       padding-left: calc(((50% /12) * 0) + 250px); } }
   @media only screen and (min-width: 1500px) {
-    .section-feature-blocks {
+    .section-feature-blocks.component-centered-container {
       padding-left: calc(50% - (750px - 290px)); } }
   @media only screen and (min-width: 1024px) {
-    .section-feature-blocks {
+    .section-feature-blocks.component-centered-container {
       margin-bottom: 44px; } }
-  .section-feature-blocks .feature-blocks__header .component-centered-container {
-    padding-right: 0;
-    padding-left: 0; }
-  @media only screen and (min-width: 1500px) {
-    .section-feature-blocks.right-aligned .feature-blocks__header {
-      padding-left: 0; } }
-  @media only screen and (min-width: 768px) {
-    .section-feature-blocks.right-aligned .feature-blocks__container .feature-blocks {
-      margin: 0;
-      width: 100%; } }
-  @media only screen and (min-width: 768px) {
-    .section-feature-blocks.right-aligned .feature-blocks__container .feature-blocks {
-      margin-left: -30px;
-      margin-right: -30px;
-      width: calc(100% + 60px); } }
-  @media only screen and (min-width: 1500px) {
-    .section-feature-blocks.left-aligned .feature-blocks__header {
-      padding-right: 0; } }
-  @media only screen and (min-width: 768px) {
-    .section-feature-blocks.left-aligned .feature-blocks__container .feature-blocks {
-      margin: 0;
-      width: 100%; } }
-  @media only screen and (min-width: 768px) {
-    .section-feature-blocks.left-aligned .feature-blocks__container .feature-blocks {
-      margin-left: -30px;
-      margin-right: -30px;
-      width: calc(100% + 60px); } }
+
+.section-feature-blocks .feature-blocks__header .component-centered-container {
+  padding-right: 0;
+  padding-left: 0; }
+
+@media only screen and (min-width: 1500px) {
+  .section-feature-blocks.right-aligned .feature-blocks__header {
+    padding-left: 0; } }
+
+@media only screen and (min-width: 768px) {
+  .section-feature-blocks.right-aligned .feature-blocks__container .feature-blocks {
+    margin: 0;
+    width: 100%; } }
+
+@media only screen and (min-width: 768px) {
+  .section-feature-blocks.right-aligned .feature-blocks__container .feature-blocks {
+    margin-left: -30px;
+    margin-right: -30px;
+    width: calc(100% + 60px); } }
+
+@media only screen and (min-width: 1500px) {
+  .section-feature-blocks.left-aligned .feature-blocks__header {
+    padding-right: 0; } }
+
+@media only screen and (min-width: 768px) {
+  .section-feature-blocks.left-aligned .feature-blocks__container .feature-blocks {
+    margin: 0;
+    width: 100%; } }
+
+@media only screen and (min-width: 768px) {
+  .section-feature-blocks.left-aligned .feature-blocks__container .feature-blocks {
+    margin-left: -30px;
+    margin-right: -30px;
+    width: calc(100% + 60px); } }
 
 .section-highlight-banner {
   margin-bottom: 40px; }

--- a/matson.ui_patterns.yml
+++ b/matson.ui_patterns.yml
@@ -57,6 +57,11 @@ node_stanford_event:
       label: "Audience"
       type: "text"
       preview: "Faculty, Staff, Sponsors"
+    sponsor:
+      description: "Who sponsored this event"
+      label: "Sponsor"
+      type: "text"
+      preview: "School of Earth"
     more_info:
       description: "A link to more information"
       label: "More information"

--- a/scss/layout/subsite/_section-feature-blocks.scss
+++ b/scss/layout/subsite/_section-feature-blocks.scss
@@ -1,8 +1,11 @@
 @charset "UTF-8";
 
 .section-feature-blocks {
-  @include container-offset-left-collapse;
-  @include vertical-spacing-margin;
+
+  &.component-centered-container {
+    @include container-offset-left-collapse;
+    @include vertical-spacing-margin;
+  }
 
   .feature-blocks__header {
     .component-centered-container {

--- a/templates/stanford_event/stanford-event.html.twig
+++ b/templates/stanford_event/stanford-event.html.twig
@@ -84,6 +84,18 @@
           {{ more_info }}
         </dd>
         {% endif %}
+        {% if audience|render|striptags|trim is not empty %}
+        <dt>{{ 'Audience'|t }}:</dt>
+        <dd>
+          {{ audience }}
+        </dd>
+        {% endif %}
+        {% if sponsor|render|striptags|trim is not empty %}
+        <dt>{{ 'Sponsor'|t }}:</dt>
+        <dd>
+          {{ sponsor }}
+        </dd>
+        {% endif %}
       </dl>
 
   </div>
@@ -97,15 +109,6 @@
     {{ description }}
   </div>
   {% endif %}
-
-  <dl class="definition-list">
-    {% if audience|render|striptags|trim is not empty %}
-    <dt>{{ 'Audience'|t }}:</dt>
-    <dd>
-      {{ audience }}
-    </dd>
-    {% endif %}
-  </dl>
 
   {{ content }}
 </div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adding sponsor to the events template, moving audience up

# Needed By (Date)
- Next push, if possible

# Urgency
- Not very

# Steps to Test
1. Go to an event page
2. Notice that Audience is moved up near the more Info and other links in the event header
3. Go to /admin/structure/types/manage/stanford_event/display and notice that Sponsor is now available to put a field in

# Affected Projects or Products
- Events

# Associated Issues and/or People
- EARTH-954

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)