### PR TITLE
EARTH-892: Load person library on user entity

### DIFF
--- a/matson.theme
+++ b/matson.theme
@@ -145,19 +145,17 @@ function matson_page_attachments_alter(array &$attachments) {
         $attachments['#attached']['library'][] = 'matson/sharrre';
         break;
 
-      case 'stanford_person':
-        $attachments['#attached']['library'][] = 'matson/stanford_person';
-        break;
-
       case 'stanford_spotlight':
         $attachments['#attached']['library'][] = 'matson/stanford_spotlight';
         $attachments['#attached']['library'][] = 'matson/sharrre';
         break;
-
-      case 'stanford_view_page':
-        $attachments['#attached']['library'][] = 'matson/stanford_view_page';
-        break;
     }
+  }
+
+  // User types.
+  $user = \Drupal::routeMatch()->getParameter('user');
+  if (is_object($user)) {
+    $attachments['#attached']['library'][] = 'matson/stanford_person';
   }
 
   // Attach home page library.


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Loads the stanford_person library on user entities

# Needed By (Date)
- ?

# Urgency
- ?

# Steps to Test

1. Check out this branch
2. Load up a user page
3. Check for CSS attachment

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)