### PR TITLE
EARTH-892: person twig template fixes

### DIFF
--- a/matson.ui_patterns.yml
+++ b/matson.ui_patterns.yml
@@ -169,7 +169,7 @@ node_stanford_spotlight:
       description: "Sub title"
       label: "Sub title"
       type: "text"
-      preview: "Sponsor or Important Details Could Go Here"
+      preview: "Academic Titles go here"
     department:
       description: "Department"
       label: "Department"

--- a/matson.ui_patterns.yml
+++ b/matson.ui_patterns.yml
@@ -175,6 +175,11 @@ node_stanford_spotlight:
       label: "Department"
       type: "text"
       preview: "Geological Sciences"
+    profile_link:
+       description: "Link to Stanford Profile"
+       label: "Profile"
+       type: "text"
+       preview: "<a href=\"#\">Link to Publications</a>"
     created:
       description: "Published date"
       label: "Published"

--- a/matson.ui_patterns.yml
+++ b/matson.ui_patterns.yml
@@ -117,6 +117,11 @@ node_stanford_person:
       label: "Links"
       type: "text"
       preview: "<a href=\"#\">Example link one</a> <a href=\"#\">Example link two</a>"
+    profile_link:
+      description: "Link to Stanford Profile"
+      label: "Profile"
+      type: "text"
+      preview: "<a href=\"#\">Link to Publications</a>"
     bio:
       description: "Biography."
       label: "Biography"
@@ -175,11 +180,6 @@ node_stanford_spotlight:
       label: "Department"
       type: "text"
       preview: "Geological Sciences"
-    profile_link:
-       description: "Link to Stanford Profile"
-       label: "Profile"
-       type: "text"
-       preview: "<a href=\"#\">Link to Publications</a>"
     created:
       description: "Published date"
       label: "Published"

--- a/templates/stanford_person/stanford-person.html.twig
+++ b/templates/stanford_person/stanford-person.html.twig
@@ -8,7 +8,7 @@
 
     <div class="content-type__header">
       <div class="page-title"><h1>{{ first_name }} {{ last_name }}</h1></div>
-      {% if sub_title is not empty %}
+      {% if sub_title|render|striptags|trim is not empty %}
       <div class="page-subtitle">
         <h2>
           {{ sub_title }}
@@ -17,25 +17,25 @@
       {% endif %}
 
       <dl class="definition-list">
-        {% if email is not empty %}
+        {% if email|render|striptags|trim is not empty %}
         <dt>{{ "Email"|t }}:</dt>
         <dd>
           {{ email }}
         </dd>
         {% endif %}
-        {% if phone is not empty %}
+        {% if phone|render|striptags|trim is not empty %}
         <dt>{{ "Phone"|t }}:</dt>
         <dd>
           {{ phone }}
         </dd>
         {% endif %}
-        {% if office is not empty %}
+        {% if office|render|striptags|trim is not empty %}
         <dt>{{ "Office"|t }}:</dt>
         <dd>
           {{ office }}
         </dd>
         {% endif %}
-        {% if links is not empty %}
+        {% if links|render|striptags|trim is not empty %}
         <dt>{{ "Links"|t }}:</dt>
         <dd>
           {{ links }}

--- a/templates/stanford_person/stanford-person.html.twig
+++ b/templates/stanford_person/stanford-person.html.twig
@@ -39,8 +39,14 @@
         <dt>{{ "Links"|t }}:</dt>
         <dd>
           {{ links }}
-        {% endif %}
         </dd>
+        {% endif %}
+        {% if profile_link|render|striptags|trim is not empty %}
+        <dt>{{ " "|t }}:</dt>
+        <dd>
+          {{ profile_link }}
+        </dd>
+        {% endif %}
       </dl>
     </div>
   </div>

--- a/templates/stanford_person/stanford-person.html.twig
+++ b/templates/stanford_person/stanford-person.html.twig
@@ -41,13 +41,12 @@
           {{ links }}
         </dd>
         {% endif %}
-        {% if profile_link|render|striptags|trim is not empty %}
-        <dt>{{ " "|t }}:</dt>
-        <dd>
-          {{ profile_link }}
-        </dd>
-        {% endif %}
       </dl>
+
+      {% if profile_link|render|striptags|trim is not empty %}
+        {{ profile_link }}
+      {% endif %}
+      
     </div>
   </div>
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This change makes it so that the fields that are empty (Office, Phone) really are hidden if empty.

# Needed By (Date)
- Next week, if possible

# Urgency
- Not very

# Steps to Test

1. Go to a user profile where a field isn't filled in (Office, Phone, etc.)
2. Check to see that the label for that field is not visible on the page.

# Associated Issues and/or People
- EARTH-892
- Also related to https://github.com/stanford-earth/matson/pull/157

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)