### PR TITLE
EARTH-1023: adding tags to ignore in filmcard striptags

### DIFF
--- a/patterns/molecules/film-card/film-card.html.twig
+++ b/patterns/molecules/film-card/film-card.html.twig
@@ -43,6 +43,6 @@
   {% endif %}
 
   {% if description %}
-    <p class="film-card__description">{{ description|render|striptags("<br><a><strong><b><i><em><img><span><ul><li>")|trim|raw }}</p>
+    <p class="film-card__description">{{ description|render|striptags("<br><a><strong><b><i><em><img><span><ul><li><ol><p><dl><dd>")|trim|raw }}</p>
   {% endif %}
 </div>

--- a/patterns/molecules/film-card/film-card.html.twig
+++ b/patterns/molecules/film-card/film-card.html.twig
@@ -43,6 +43,6 @@
   {% endif %}
 
   {% if description %}
-    <p class="film-card__description">{{ description|render|striptags("<br><a><strong><b><i><em><img><span>")|trim|raw }}</p>
+    <p class="film-card__description">{{ description|render|striptags("<br><a><strong><b><i><em><img><span><ul><li>")|trim|raw }}</p>
   {% endif %}
 </div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Clare needs bullets in the filmcard description field but the twig template was stripped them out.

# Needed By (Date)
- End of sprint

# Urgency
- Not very

# Steps to Test

1. go to /sesur (this page isn't published so you will want to log in)
2. Go to "The Proposal" section
3. Look at the Film Card description field under Basic Information
4> See if there are UL/LI tags there.

# Affected Projects or Products
- None

# Associated Issues and/or People
- EARTH-1023

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)