### PR TITLE
EARTH-1166: Byline Padding

### DIFF
--- a/css/theme/stanford-news.css
+++ b/css/theme/stanford-news.css
@@ -165,7 +165,9 @@ h1 {
   color: #4d4f53; }
 
 .field-s-news-author {
-  text-transform: uppercase; }
+  text-transform: uppercase;
+  padding-top: 10px;
+  padding-bottom: 10px; }
   @media only screen and (min-width: 1024px) {
     .field-s-news-author {
       padding-left: 110px; } }

--- a/scss/theme/stanford-news.scss
+++ b/scss/theme/stanford-news.scss
@@ -40,6 +40,8 @@ h1 {
 // Author field.
 .field-s-news-author {
   text-transform: uppercase;
+  padding-top: 10px;
+  padding-bottom: 10px;
 
   @include grid-media($media-lg) {
     padding-left: 110px;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adding padding around news author name

# Needed By (Date)
- Next push

# Urgency
- Not urgent.

# Steps to Test

1. Disable Earth-1166 CSS injector rule
2. Go to news story
3. Look to see 10px padding above and below author name 

# Affected Projects or Products
- Earth Matters, School Highlights

# Associated Issues and/or People
- Earth 1166
- Dee Tucker

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)