### PR TITLE
EARTH-1154: Hyphen top in WYSIWIG

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -3854,6 +3854,8 @@ ul.tabs {
       transform: translateY(-50%);
       background-color: #8c1515;
       left: 0; }
+    .field-p-wysiwyg h2::after {
+      top: .7em; }
   .field-p-wysiwyg h3 {
     font-size: 1.6em; }
   .field-p-wysiwyg figure {

--- a/scss/components/wysiwyg/_wysiwyg.scss
+++ b/scss/components/wysiwyg/_wysiwyg.scss
@@ -38,6 +38,9 @@
   h2 {
     @include dash-left-offset;
     font-size: 1.8em;
+    &::after {
+      top: .7em;
+    }
   }
 
   h3 {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- WYSIWIG Hyphen before H2 doesn't align properly with long h2s. Using Aaron's CSS to fix.

# Needed By (Date)
- Next push

# Urgency
- Not at all. CSS injector rule doing it now

# Steps to Test

1. Find a page with a long H2 (for example, https://earth.stanford.edu/inside/knowledge/general-transition-guidance#gs.brg2os, nearer the bottom of the page.)
2. Then disable CSS injector rule EARTH-1154
3. Check that hyphen is centered vertically on first letter, not between the lines.

# Affected Projects or Products
- Sitewide WYSIWIG h2s

# Associated Issues and/or People
- EARTH-1154

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)