### PR TITLE
EARTH-934: Reduce padding to accommodate long names

### DIFF
--- a/css/layout/stanford-subsite.css
+++ b/css/layout/stanford-subsite.css
@@ -78,7 +78,7 @@
     width: 190px; } }
 
 #floating_sidebar__wrapper .floating_sidebar > h2 {
-  padding: 7px 30px;
+  padding: 7px 13px;
   margin-bottom: 20px;
   display: block;
   background: #017c92;

--- a/scss/layout/subsite/_floating-sidebar.scss
+++ b/scss/layout/subsite/_floating-sidebar.scss
@@ -19,7 +19,7 @@
   // Title Styles.
   .floating_sidebar {
     > h2 {
-      padding: 7px 30px;
+      padding: 7px 13px;
       margin-bottom: 20px;
       display: block;
       background: color(action);


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
_See ticket:  https://stanfordits.atlassian.net/browse/EARTH-934_

# Needed By (Date)
- Soon

# Urgency
- Fixes broken stuff

# Steps to Test

- Checkout this branch
- Navigate to a subsite such as: https://earth.stanford.edu/sustNEW#gs.zbl9kb
- Verify you see that the program name in the right sidebar looks acceptable

![Screen Shot 2019-08-27 at 12 52 48 PM](https://user-images.githubusercontent.com/284440/63964904-f1871d80-ca4c-11e9-9c67-83580728119d.png)


![Screen Shot 2019-08-27 at 12 52 58 PM](https://user-images.githubusercontent.com/284440/63964921-f8159500-ca4c-11e9-9660-49e1deb34556.png)


# Affected Projects or Products
- Earth (https://earth.stanford.edu)

# Associated Issues and/or People
## Related JIRA ticket(s)
https://stanfordits.atlassian.net/browse/EARTH-934

## Related PRs
None

## More Information
The ticket said to reduce font size. However, I thought that the font size was already fairly small, and I wanted to just try adjusting the padding. Let me know if this works.

## Folks to notify
`@buttonwillowsix`

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)