### PR TITLE
8.x-1.x-EARTH-1068: remove end quote from block and pull quotes

### DIFF
--- a/css/base/base.css
+++ b/css/base/base.css
@@ -3418,13 +3418,6 @@ hr {
     top: 12px;
     left: -24px;
     content: '‘‘'; }
-  .text-with-summary .pullquote-large::after,
-  .text-with-summary blockquote::after,
-  .text-with-summary q::after {
-    content: '’’';
-    position: absolute;
-    right: 0px;
-    bottom: -21px; }
 
 .lead-text {
   font-size: 1.776889em;

--- a/scss/base/_typography.scss
+++ b/scss/base/_typography.scss
@@ -310,13 +310,6 @@ $su-brand-Stanford: "\1f57d";
       left: -24px;
       content: '‘‘';
     }
-
-    &::after {
-      content: '’’';
-      position: absolute;
-      right: 0px;
-      bottom: -21px;
-    }
   }
 }
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
_See ticket:  https://stanfordits.atlassian.net/browse/EARTH-1228_

# Needed By (Date)
- Soon

# Urgency
- Fixes broken stuff

# Steps to Test

- Checkout this branch
- From the WYSIWYG, create a `<blockquote>`.
- Save
- Verify it has no end quote.
- Repeat with `pull-quote` style


# Affected Projects or Products
- Earth (https://earth.stanford.edu)

# Associated Issues and/or People
## Related JIRA ticket(s)
https://stanfordits.atlassian.net/browse/EARTH-1228

## More Information
This change affects styles for  blockquotes, pullquotes, and q.
![Screen Shot 2019-08-27 at 1 22 09 PM](https://user-images.githubusercontent.com/284440/63805205-c1654080-c8cd-11e9-8bd3-3293a43d7016.png)


## Folks to notify
`@buttonwillowsix`

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)

