### PR TITLE
8.x 1.x earth 1068 quote styling

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -617,6 +617,10 @@
   letter-spacing: .5px;
   line-height: 1.3em; }
 
+@media only screen and (max-width: 767px) {
+  .quote-card__quote p:first-of-type {
+    margin-bottom: 0; } }
+
 .quote-card__source {
   position: relative; }
   .quote-card__source::before {

--- a/patterns/molecules/quote-card/css/quote-card.component.css
+++ b/patterns/molecules/quote-card/css/quote-card.component.css
@@ -33,6 +33,6 @@
     .quote-card__icon {
       position: absolute;
       top: 10px;
-      left: -60px; } }
+      left: -45px; } }
 
 /*# sourceMappingURL=quote-card.component.css.map */

--- a/patterns/molecules/quote-card/scss/quote-card.component.scss
+++ b/patterns/molecules/quote-card/scss/quote-card.component.scss
@@ -46,6 +46,6 @@
   @include grid-media($media-md) {
     position: absolute;
     top: 10px;
-    left: -60px;
+    left: -45px;
   }
 }

--- a/scss/components/quote-card/_quote-card.scss
+++ b/scss/components/quote-card/_quote-card.scss
@@ -32,6 +32,11 @@
     font-size: em(26px);
     letter-spacing: .5px;
     line-height: 1.3em;
+
+  &:first-of-type {
+    @include grid-media($media-sm-max) {
+      margin-bottom: 0;
+    }
   }
 }
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
_See ticket:  https://stanfordits.atlassian.net/browse/EARTH-1068_
This adjusts the position of the first quote mark for the Quote Banner paragraph.

# Needed By (Date)
- Soon

# Urgency
- Fixes broken stuff


# Steps to Test

- Checkout this branch
-  Create a Complex Page
- Add a Quote Banner
- Save
- Verify the first quote appears as expected at all breakpoints.

![Screen Shot 2019-08-27 at 2 45 39 PM](https://user-images.githubusercontent.com/284440/63871585-fd9dad00-c970-11e9-8133-b88c73461761.png)


<img width="610" alt="Screen Shot 2019-08-28 at 8 40 40 AM" src="https://user-images.githubusercontent.com/284440/63871558-f2e31800-c970-11e9-8561-19410df7fbf9.png">


# Affected Projects or Products
- Earth (https://earth.stanford.edu)

# Associated Issues and/or People
## Related JIRA ticket(s)
https://stanfordits.atlassian.net/browse/EARTH-1068


## Folks to notify
@aaroncole 
@buttonwillowsix

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)