### PR TITLE
EARTH-1032: change centering of hyphen

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -483,7 +483,8 @@
   text-align: center; }
   .callout-card .callout-card__title {
     position: absolute;
-    top: 50%;
+    /* top: 50%; */
+    top: .7em;
     margin-top: auto;
     margin-bottom: auto;
     left: 50%;
@@ -519,7 +520,8 @@
       fill: #8c1515; }
   .callout-card .callout-card__icon {
     position: absolute;
-    top: 50%;
+    /* top: 50%; */
+    top: .7em;
     margin-top: auto;
     margin-bottom: auto;
     left: 50%;
@@ -616,10 +618,9 @@
   font-size: 1.625em;
   letter-spacing: .5px;
   line-height: 1.3em; }
-
-@media only screen and (max-width: 767px) {
-  .quote-card__quote p:first-of-type {
-    margin-bottom: 0; } }
+  @media only screen and (max-width: 767px) {
+    .quote-card__quote p:first-of-type {
+      margin-bottom: 0; } }
 
 .quote-card__source {
   position: relative; }
@@ -972,7 +973,8 @@
   user-select: none; }
   .drop-cap-title__drop-cap.drop-cap--is-centered {
     position: absolute;
-    top: 50%;
+    /* top: 50%; */
+    top: .7em;
     margin-top: auto;
     margin-bottom: auto;
     left: 50%;
@@ -3669,7 +3671,8 @@ html .getsocial {
 @media only screen and (min-width: 1024px) {
   .social-card__content {
     position: absolute;
-    top: 50%;
+    /* top: 50%; */
+    top: .7em;
     margin-top: auto;
     margin-bottom: auto;
     -webkit-transform: translateY(-50%);
@@ -3925,7 +3928,8 @@ ul.tabs {
     font-size: 1.8em; }
     .field-p-wysiwyg h2::after {
       position: absolute;
-      top: 50%;
+      /* top: 50%; */
+      top: .7em;
       margin-top: auto;
       margin-bottom: auto;
       -webkit-transform: translateY(-50%);

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -622,9 +622,9 @@
     .quote-card__quote p:first-of-type {
       margin-bottom: 0; } }
 
-.quote-card__source {
+.quote-card__quote .quote-card__source {
   position: relative; }
-  .quote-card__source::before {
+  .quote-card__quote .quote-card__source::before {
     background-color: #D8D8D8;
     content: '';
     display: block;
@@ -633,7 +633,7 @@
     left: 0;
     width: 70px;
     height: 1px; }
-  .quote-card__source strong {
+  .quote-card__quote .quote-card__source strong {
     color: #8c1414;
     display: block;
     font-style: normal;

--- a/css/components/components.css
+++ b/css/components/components.css
@@ -483,8 +483,7 @@
   text-align: center; }
   .callout-card .callout-card__title {
     position: absolute;
-    /* top: 50%; */
-    top: .7em;
+    top: 50%;
     margin-top: auto;
     margin-bottom: auto;
     left: 50%;
@@ -520,8 +519,7 @@
       fill: #8c1515; }
   .callout-card .callout-card__icon {
     position: absolute;
-    /* top: 50%; */
-    top: .7em;
+    top: 50%;
     margin-top: auto;
     margin-bottom: auto;
     left: 50%;
@@ -973,8 +971,7 @@
   user-select: none; }
   .drop-cap-title__drop-cap.drop-cap--is-centered {
     position: absolute;
-    /* top: 50%; */
-    top: .7em;
+    top: 50%;
     margin-top: auto;
     margin-bottom: auto;
     left: 50%;
@@ -3671,8 +3668,7 @@ html .getsocial {
 @media only screen and (min-width: 1024px) {
   .social-card__content {
     position: absolute;
-    /* top: 50%; */
-    top: .7em;
+    top: 50%;
     margin-top: auto;
     margin-bottom: auto;
     -webkit-transform: translateY(-50%);
@@ -3927,14 +3923,9 @@ ul.tabs {
     padding-left: .9em;
     font-size: 1.8em; }
     .field-p-wysiwyg h2::after {
-      position: absolute;
-      /* top: 50%; */
       top: .7em;
       margin-top: auto;
       margin-bottom: auto;
-      -webkit-transform: translateY(-50%);
-      -ms-transform: translateY(-50%);
-      transform: translateY(-50%);
       background-color: #8c1515;
       left: 0; }
     .field-p-wysiwyg h2::after {

--- a/css/layout/stanford-subsite.css
+++ b/css/layout/stanford-subsite.css
@@ -795,14 +795,9 @@
   position: relative;
   padding-left: .9em; }
   .field-p-wysiwyg h2::after {
-    position: absolute;
-    /* top: 50%; */
     top: .7em;
     margin-top: auto;
     margin-bottom: auto;
-    -webkit-transform: translateY(-50%);
-    -ms-transform: translateY(-50%);
-    transform: translateY(-50%);
     background-color: #8c1515;
     left: 0; }
 

--- a/css/layout/stanford-subsite.css
+++ b/css/layout/stanford-subsite.css
@@ -796,7 +796,8 @@
   padding-left: .9em; }
   .field-p-wysiwyg h2::after {
     position: absolute;
-    top: 50%;
+    /* top: 50%; */
+    top: .7em;
     margin-top: auto;
     margin-bottom: auto;
     -webkit-transform: translateY(-50%);

--- a/css/theme/stanford-news.css
+++ b/css/theme/stanford-news.css
@@ -355,7 +355,8 @@ figure.align-center .figure-container {
   margin-bottom: 20px; }
   .field-p-wysiwyg h2::after {
     position: absolute;
-    top: 50%;
+    /* top: 50%; */
+    top: .7em;
     margin-top: auto;
     margin-bottom: auto;
     -webkit-transform: translateY(-50%);

--- a/css/theme/stanford-news.css
+++ b/css/theme/stanford-news.css
@@ -354,14 +354,9 @@ figure.align-center .figure-container {
   padding-left: .9em;
   margin-bottom: 20px; }
   .field-p-wysiwyg h2::after {
-    position: absolute;
-    /* top: 50%; */
     top: .7em;
     margin-top: auto;
     margin-bottom: auto;
-    -webkit-transform: translateY(-50%);
-    -ms-transform: translateY(-50%);
-    transform: translateY(-50%);
     background-color: #8c1515;
     left: 0; }
 

--- a/scss/components/quote-card/_quote-card.scss
+++ b/scss/components/quote-card/_quote-card.scss
@@ -39,28 +39,29 @@
       }
     }
   }
-}
 
-.quote-card__source {
-  position: relative;
 
-  &::before {
-    background-color: color(smoke);
-    content: '';
-    display: block;
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 70px;
-    height: 1px;
-  }
+  .quote-card__source {
+    position: relative;
 
-  strong {
-    color: color(dark-red);
-    display: block;
-    font-style: normal;
-    font-size: em(12px);
-    letter-spacing: .9px;
-    text-transform: uppercase;
+    &::before {
+      background-color: color(smoke);
+      content: '';
+      display: block;
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 70px;
+      height: 1px;
+    }
+
+    strong {
+      color: color(dark-red);
+      display: block;
+      font-style: normal;
+      font-size: em(12px);
+      letter-spacing: .9px;
+      text-transform: uppercase;
+    }
   }
 }

--- a/scss/components/quote-card/_quote-card.scss
+++ b/scss/components/quote-card/_quote-card.scss
@@ -33,9 +33,10 @@
     letter-spacing: .5px;
     line-height: 1.3em;
 
-  &:first-of-type {
-    @include grid-media($media-sm-max) {
-      margin-bottom: 0;
+    &:first-of-type {
+      @include grid-media($media-sm-max) {
+        margin-bottom: 0;
+      }
     }
   }
 }

--- a/scss/utilities/mixins/_center-transform.scss
+++ b/scss/utilities/mixins/_center-transform.scss
@@ -4,7 +4,8 @@
   position: absolute;
 
   @if $axis != x {
-    top: 50%;
+    /* top: 50%; */
+    top: .7em;
     margin-top: auto;
     margin-bottom: auto;
   }

--- a/scss/utilities/mixins/_center-transform.scss
+++ b/scss/utilities/mixins/_center-transform.scss
@@ -4,8 +4,7 @@
   position: absolute;
 
   @if $axis != x {
-    /* top: 50%; */
-    top: .7em;
+    top: 50%;
     margin-top: auto;
     margin-bottom: auto;
   }

--- a/scss/utilities/mixins/_text-decoration.scss
+++ b/scss/utilities/mixins/_text-decoration.scss
@@ -73,7 +73,10 @@
 
   &::after {
     @extend %dash-under;
-    @include center-transform(y);
+    // @include center-transform(y);
+    top: .7em;
+    margin-top: auto;
+    margin-bottom: auto;
     background-color: color($dash-color);
     left: 0;
   }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
_See ticket:  https://stanfordits.atlassian.net/browse/EARTH-1032_
This moves the dash before the H2 to be centered around the first line and not all the lines of the H2.

# Needed By 
- Soon

# Urgency
- Client is eagerly awaiting this.
- Fixes broken stuff

# Steps to Test

- Checkout this branch
- Navigate to https://earth.stanford.edu/news/what-do-midterm-results-mean-environmental-policy#gs.pj46sz
- Verify you see the hyphen centered with the first line of the H2, not the _whole_ H2.

# Affected Projects or Products
- Earth (https://earth.stanford.edu)

# Associated Issues and/or People
## Related JIRA ticket(s)
https://stanfordits.atlassian.net/browse/EARTH-1032

## Related PRs

## More Information
I found a missing "}" in `_quote-card.scss`. I added one back in. I hope I put it in the right place. 

## Folks to notify

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)