### PR TITLE
Replaced Mailchimp form in the footer with a link

### DIFF
--- a/templates/components/global-footer/global-footer.html.twig
+++ b/templates/components/global-footer/global-footer.html.twig
@@ -33,17 +33,10 @@
     <div class="contact-footer__subscribe">
       <h2>{{ 'Subscribe to Stanford Earth Matters'|trans }}</h2>
       <p>{{ 'Our Monthly Research News Alert'|trans }}</p>
-      <div id="mc_embed_signup">
-        <form action="//stanford.us7.list-manage.com/subscribe/post?u=167e9da7acec83c4cc802b3e7&amp;id=69d6fa9e3a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate subscribe-form" target="_blank" novalidate>
-          <div id="mc_embed_signup_scroll">
-            <input type="email" value="" name="EMAIL" class="email email-input" id="mce-EMAIL" class="email-input" placeholder="name@stanford.edu" required  aria-label="Email Address">
-            <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-            <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_167e9da7acec83c4cc802b3e7_69d6fa9e3a" tabindex="-1" value=""></div>
-            <div class="clear"><input type="submit" value="Subscribe" name="{{ 'Join'|t }}" id="mc-embedded-subscribe" class="button button__hollow" aria-label="Subscribe"></div>
-          </div>
-        </form>
-      </div>
+      <a class="button__hollow" href="https://stanford.us7.list-manage.com/subscribe/post?u=167e9da7acec83c4cc802b3e7&id=69d6fa9e3a">Subscribe</a>
     </div>
+
+
   </section>
 
   <section id="footer__global-footer">


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Mailchimp form in the global footer had an accessibility issue and resulted in an error on the Mailchimp side.  I replaced the form with a simple link to the form on the Mailchimp website, similar to what is done on the Earth Matters page.
- I also removed the "Expected Graduation Date" field from the MC form per Barbara's request.
- Moving the GDPR content above the Industry field per Barb's request was not possible.

# Needed By (Date)
- At the next available production push

# Steps to Test

1. Scroll to the bottom of any page
2. Select the "Subscribe" button/link
3. Verify that there is no error.
4. Verify that the "Expected Graduation Date" field is not visible.

# Affected versions or modules
- None

# Associated Issues and/or People
- EARTH-1404

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)