### PR TITLE
Earth 1405 blazy background images

### DIFF
--- a/patterns/molecules/link-banner/link-banner.html.twig
+++ b/patterns/molecules/link-banner/link-banner.html.twig
@@ -4,9 +4,9 @@
  * Link banner pattern.
  */
 #}
-{% set attributes = attributes.addClass('link-banner') %}
+{% set attributes = attributes.addClass('link-banner b-lazy bg') %}
 {% if image|get_img_src is not empty %}
-  {% set attributes = attributes.setAttribute('style', ['background-image:url(' ~ image|get_img_src ~ ')']) %}
+  {% set attributes = attributes.setAttribute('data-src', image|get_img_src ) %}
 {% endif %}
 
 <div{{ attributes }}>

--- a/patterns/molecules/postcard/postcard.html.twig
+++ b/patterns/molecules/postcard/postcard.html.twig
@@ -7,7 +7,7 @@
 {% set attributes = attributes.addClass(['postcard', variants.image_orientation, variants._text_orientation]) %}
 
 <div{{ attributes }}> {# has-image-right, has-text-offset, has-text-inset #}
-  <div class="postcard__image" style="background-image:url('{{ image|get_img_src }}')"></div>
+  <div class="postcard__image b-lazy bg" data-src="{{ image|get_img_src }}"></div>
   <div class="postcard__content">
     <div class="postcard__content-inner">
       <div class="postcard__content-text">

--- a/patterns/organisms/section-expandable-banner/section-expandable-banner.html.twig
+++ b/patterns/organisms/section-expandable-banner/section-expandable-banner.html.twig
@@ -5,10 +5,10 @@
  */
 #}
 
-{% set classes = ['section-expandable-banner', 'js-section-expandable-banner'] %}
+{% set classes = ['section-expandable-banner', 'js-section-expandable-banner', 'b-lazy', 'bg'] %}
 {% set header_vars = {'superhead': superhead, 'subhead': subhead, 'context': context} %}
 
-<div{{ attributes.addClass(classes) }} style="background-image:url({{ image|get_img_src }})">
+<div{{ attributes.addClass(classes) }} data-src="{{ image|get_img_src }}">
   <div class="expandable-banner__header">
     {{ pattern('section_header', header_vars) }}
   </div>

--- a/patterns/organisms/section-highlight-banner/section-highlight-banner.html.twig
+++ b/patterns/organisms/section-highlight-banner/section-highlight-banner.html.twig
@@ -11,7 +11,8 @@
 {% endif %}
 
 {% if image|get_img_src is not empty %}
-  {% set attributes = attributes.setAttribute('style', ['background-image:url(' ~ image|get_img_src ~ ')']) %}
+  {% set attributes = attributes.addClass('b-lazy bg') %}
+  {% set attributes = attributes.setAttribute('data-src', image|get_img_src ) %}
 {% endif %}
 
 {% set header_vars = {'superhead': superhead, 'subhead': subhead, 'context': context} %}

--- a/templates/components/global-footer/global-footer.html.twig
+++ b/templates/components/global-footer/global-footer.html.twig
@@ -6,7 +6,7 @@
 #}
 
 <footer id="footer__container">
-  <section class="contact-footer" style="background-image:url('{{ base_path ~ directory }}/img/optimized/footer-bg.jpg')";>
+  <section class="contact-footer b-lazy bg" data-src="{{ base_path ~ directory }}/img/optimized/footer-bg.jpg";>
     <div class="contact-footer__brand">
       {{ drupal_entity('block', 'matson_branding')|render|preg_replace("/(block-matson-branding)/", "footer__block-matson-branding")|raw }}
     </div>


### PR DESCRIPTION
# NOT READY

# Summary
- Update all P/Ts with CSS background images to use lazy-loading

# Needed By (Date)
- Next production push

# Steps to Test

1. Open any page with a Section Expandable, Section Highlight Banner,  Postcard, and/or Link Banner.
2. Also, check the global footer image.
3. Open the Network panel in Devtools (Chrome/Firefox)
4. Watch to see if the images load only once their content is scrolled into the viewport

# Affected versions or modules
- None

# Associated Issues and/or People
- EARTH-1505

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)