### PR TITLE
Adding styling for inline links within the body content areas.

### DIFF
--- a/css/base/base.css
+++ b/css/base/base.css
@@ -3427,4 +3427,20 @@ hr {
 body {
   color: #4d4f53; }
 
+.field-p-wysiwyg p a,
+li:not(.menu-item) a,
+.field-p-wysiwyg a {
+  text-decoration: none;
+  font-weight: bold;
+  border-bottom: 2px dotted transparent;
+  transition: .25s; }
+
+.field-p-wysiwyg a:hover,
+.field-p-wysiwyg a:active,
+p a:hover,
+p a:active,
+li:not(.menu-item) a:hover,
+li:not(.menu-item) a:active {
+  border-color: #f9b002; }
+
 /*# sourceMappingURL=base.css.map */

--- a/css/theme/stanford-news.css
+++ b/css/theme/stanford-news.css
@@ -360,9 +360,6 @@ figure.align-center .figure-container {
     background-color: #8c1515;
     left: 0; }
 
-.field-p-wysiwyg a {
-  text-decoration: underline; }
-
 .field-p-responsive-image-cred {
   color: #4d4f53;
   text-align: left; }

--- a/scss/base/_typography.scss
+++ b/scss/base/_typography.scss
@@ -322,3 +322,22 @@ $su-brand-Stanford: "\1f57d";
 body {
   color: color(stone);
 }
+
+// Styling for inline links
+.field-p-wysiwyg p a,
+li:not(.menu-item) a,
+.field-p-wysiwyg a {
+  text-decoration: none;
+  font-weight: bold;
+  border-bottom: 2px dotted transparent;
+  transition: .25s;
+}
+
+.field-p-wysiwyg a:hover,
+.field-p-wysiwyg a:active,
+p a:hover,
+p a:active,
+li:not(.menu-item) a:hover,
+li:not(.menu-item) a:active {
+  border-color: #f9b002;
+}

--- a/scss/theme/stanford-news.scss
+++ b/scss/theme/stanford-news.scss
@@ -244,9 +244,6 @@ figure.align-center .figure-container {
     margin-bottom: 20px;
   }
 
-  a {
-    text-decoration: underline;
-  }
 }
 
 .field-p-responsive-image-cred {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Moving inline link styling from CSS injector into the theme

# Needed By (Date)
- When evs

# Steps to Test

1. Go to /news/what-other-planets-can-teach-us-about-earth
2. Inline links should be bold
3. Hover any of the inline links and see a double-dotted orange bottom border
4. Go to the homepage
5. Verify that all other links are normal

# Associated Issues and/or People
- JIRA ticket EARTH-1324

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)