### PR TITLE
EARTH-1356: change highlight card intro color

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -1822,7 +1822,7 @@ html .getsocial {
       fill: #9c9d9e; }
 
 .highlight-card__intro {
-  color: #f9b002;
+  color: #8c1515;
   display: block;
   font-size: 0.75em;
   letter-spacing: 0.9px;

--- a/scss/components/highlight-banner/_highlight-banner.scss
+++ b/scss/components/highlight-banner/_highlight-banner.scss
@@ -45,7 +45,7 @@
 }
 
 .highlight-card__intro {
-  color: color(emphasis);
+  color: color(brand);
   display: block;
   font-size: em(12px);
   letter-spacing: 0.9px;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Color contrast on highlight card small text

# Needed By (Date)
- eventually

# Urgency
- medium

# Steps to Test

1. Load up this branch
2. Visit the homepage
3. Test color contrast on highlight card text that says "Spring Quarter, 3 credits"
4. Verify that using Stanford red is OK? We could also do blue?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- EARTH-1356
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)