### PR TITLE
EARTH-1409 Adding b-lazy class to <iframe> element.

### DIFF
--- a/templates/fields/video-embed-iframe.html.twig
+++ b/templates/fields/video-embed-iframe.html.twig
@@ -1,0 +1,7 @@
+{#
+/**
+ * @file
+ * Display an iframe with alterable components.
+ */
+#}
+<iframe class="b-lazy"{{ attributes }}{% if url is not empty %} data-src="{{ url }}{% if query is not empty %}?{{ query | url_encode }}{% endif %}{% if fragment is not empty %}#{{ fragment }}{% endif %}"{% endif %}></iframe>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adding lazy loading to video embeds to speed up page load.

# Needed By (Date)
- Next production push

# Steps to Test

1. Navigate to the FIeld Learning page (/academics/field-learning)
2. Inspect any of the three videos on the page
3. Verify that the b-lazy and b-loaded classes are added to the <iframe> element.

# Associated Issues and/or People
- JIRA ticket EARTH-1409

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)