### PR TITLE
EARTH-1218: User titles to be rendered as unordered list

### DIFF
--- a/templates/stanford_person/field--default--user--field-s-person-titles.html.twig
+++ b/templates/stanford_person/field--default--user--field-s-person-titles.html.twig
@@ -1,0 +1,42 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
+
+{% for item in items %}
+  <li>{{ item.content }}</li>  
+{% endfor %}

--- a/templates/stanford_person/stanford-person.html.twig
+++ b/templates/stanford_person/stanford-person.html.twig
@@ -10,7 +10,9 @@
       <div class="page-title"><h1>{{ first_name }}</h1></div>
       {% if sub_title|render|striptags|trim is not empty %}
       <div class="page-subtitle">
-      {{ sub_title }}
+        <ul>
+          {{ sub_title }}  
+        </ul>
       </div>
       {% endif %}
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Currently on user profiles, we display the academic titles field as an unordered list by applying some styles. This PR turns it into a real unordered list so we can remove styling and also have more consistent display (the html field sometimes causes the styled bullet to drop down a line.)
This includes a new template for the person titles field, but only in the scope of the default user view.

# Needed By (Date)
- Next push

# Urgency
- Not

# Steps to Test

1. Pull down this branch
2. Select a user and make sure they have some text in the "TITLES WITH LINKS" field
3. Remove the expert display suite class name for that field in Manage Display (that way you ensure you don't get those bullets that way.)
4. Clear all caches
5. Hopefully see beautiful bullets :)

# Affected Projects or Products
- Person

# Associated Issues and/or People
- JIRA ticket
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)