### PR TITLE
EARTH-1405-blazy-background-images Removing semicolon.

### DIFF
--- a/templates/components/global-footer/global-footer.html.twig
+++ b/templates/components/global-footer/global-footer.html.twig
@@ -6,7 +6,7 @@
 #}
 
 <footer id="footer__container">
-  <section class="contact-footer b-lazy bg" data-src="{{ base_path ~ directory }}/img/optimized/footer-bg.jpg";>
+  <section class="contact-footer b-lazy bg" data-src="{{ base_path ~ directory }}/img/optimized/footer-bg.jpg">
     <div class="contact-footer__brand">
       {{ drupal_entity('block', 'matson_branding')|render|preg_replace("/(block-matson-branding)/", "footer__block-matson-branding")|raw }}
     </div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removed semi-colon leftover from a previous edit

# Needed By (Date)
- Next push

# Associated Issues and/or People
- JIRA ticket EARTH-1405
- Shea found this while investigating the background images not appearing

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)