### PR TITLE
EARTH-1421: responsive image bg

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -2960,12 +2960,16 @@ html .getsocial {
 
 .field-p-responsive-media picture,
 .field--responsive-image picture,
+.field-p-responsive-media .media,
+.field--responsive-image .media,
 .field--responsive-video {
   position: relative;
   margin-bottom: 20px;
   display: block; }
   .field-p-responsive-media picture::after,
   .field--responsive-image picture::after,
+  .field-p-responsive-media .media::after,
+  .field--responsive-image .media::after,
   .field--responsive-video::after {
     content: '';
     background-color: #F9F6EF;
@@ -2980,6 +2984,8 @@ html .getsocial {
     z-index: -1; }
   .field-p-responsive-media picture img,
   .field--responsive-image picture img,
+  .field-p-responsive-media .media img,
+  .field--responsive-image .media img,
   .field--responsive-video img {
     width: 100%;
     max-width: none;

--- a/scss/components/responsive-media/_responsive-media.scss
+++ b/scss/components/responsive-media/_responsive-media.scss
@@ -11,6 +11,8 @@
 
 .field-p-responsive-media picture,
 .field--responsive-image picture,
+.field-p-responsive-media .media,
+.field--responsive-image .media,
 .field--responsive-video {
   position: relative;
   margin-bottom: 20px;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Put back the sandstone stripe behind responsive images

# Needed By (Date)
- Next merge

# Urgency
- Not very

# Steps to Test

1. Checkout this branch
2. If you've pulled down production recently, make surer the css injector rule labelled EARRTH-1421 is disabled
3. Look at a page with responsive image and look for the BG, for example, /news/photos-inspire-more-sustainable-world#gs.6t1v4t

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/EARTH-1421

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)