### PR TITLE
WIP Earth 1312 change padding margin styles for filmstrip only on subsite pages

### DIFF
--- a/css/layout/stanford-subsite.css
+++ b/css/layout/stanford-subsite.css
@@ -54,13 +54,23 @@
 
 @media only screen and (min-width: 768px) {
   .filmstrip {
-    margin-left: calc(((50% /12) * 0) + 280px);
-    margin-right: calc(((50% /12) * 0) + 50px); } }
+    padding-left: calc(((50% /12) * 0) + 280px);
+    padding-right: calc(((50% /12) * 0) + 50px); } }
 
 @media only screen and (min-width: 1500px) {
   .filmstrip {
-    margin-left: calc(50% - (750px - 320px));
-    margin-right: calc(50% - (750px - 60px)); } }
+    padding-left: calc(50% - (750px - 320px));
+    padding-right: calc(50% - (750px - 60px)); } }
+
+@media only screen and (min-width: 768px) {
+  .filmstrip.component-centered-container {
+    padding-left: calc(((50% /12) * 0) + 280px);
+    padding-right: calc(((50% /12) * 0) + 50px); } }
+
+@media only screen and (min-width: 1500px) {
+  .filmstrip.component-centered-container {
+    padding-left: calc(50% - (750px - 320px));
+    padding-right: calc(50% - (750px - 60px)); } }
 
 .filmstrip.is-flexible {
   max-width: 420px; }
@@ -460,9 +470,6 @@
     .section-callout-filmstrip.header-to-top {
       padding-left: calc(50% - (750px - 320px));
       padding-right: calc(50% - (750px - 60px)); } }
-  @media only screen and (min-width: 1024px) {
-    .section-callout-filmstrip.header-to-top .component-centered-container {
-      padding: 0; } }
   @media only screen and (max-width: 575px) {
     .section-callout-filmstrip.header-to-top .section-header {
       padding: 1em calc(((50% /12) * 0) + 15px); }

--- a/scss/layout/subsite/_filmstrip.scss
+++ b/scss/layout/subsite/_filmstrip.scss
@@ -3,7 +3,7 @@
 .filmstrip {
   @include container-offset-left;
   &.component-centered-container {
-	  @include container-offset-left; // need to be specific in overridding
+    @include container-offset-left; // need to be specific in overridding
   }
 
   &.is-flexible {

--- a/scss/layout/subsite/_filmstrip.scss
+++ b/scss/layout/subsite/_filmstrip.scss
@@ -1,7 +1,10 @@
 @charset "UTF-8";
 
 .filmstrip {
-  @include container-offset-left-margin;
+	@include container-offset-left;
+	&.component-centered-container {
+		@include container-offset-left; // need to be specific in overridding
+	}
   &.is-flexible {
     max-width: 420px;
 

--- a/scss/layout/subsite/_filmstrip.scss
+++ b/scss/layout/subsite/_filmstrip.scss
@@ -1,10 +1,11 @@
 @charset "UTF-8";
 
 .filmstrip {
-	@include container-offset-left;
-	&.component-centered-container {
+  @include container-offset-left;
+  &.component-centered-container {
 		@include container-offset-left; // need to be specific in overridding
-	}
+  }
+
   &.is-flexible {
     max-width: 420px;
 

--- a/scss/layout/subsite/_filmstrip.scss
+++ b/scss/layout/subsite/_filmstrip.scss
@@ -3,7 +3,7 @@
 .filmstrip {
   @include container-offset-left;
   &.component-centered-container {
-		@include container-offset-left; // need to be specific in overridding
+	  @include container-offset-left; // need to be specific in overridding
   }
 
   &.is-flexible {

--- a/scss/layout/subsite/_section-callout-filmstrip.scss
+++ b/scss/layout/subsite/_section-callout-filmstrip.scss
@@ -42,12 +42,6 @@
     @include responsive-container($default-container);
     @include container-offset-left;
 
-    .component-centered-container {
-      @include grid-media($media-lg) {
-        padding: 0;
-      }
-    }
-
     .section-header {
       @include responsive-container($default-container);
     }


### PR DESCRIPTION
So this solution shouldn't affect non-subsite pages, but I want to do some testing to make sure it doesn't affect any pages we don't want changed.
Please note that I have applied some styles to .filmstrip and there are different filmstrips so I'm not sure 100% if there are any .filmstrips on a subsite page that you DON'T want moved to the right to accomodate for the left navigation section..

This is what the section looks like that I'm looking at.
![image](https://user-images.githubusercontent.com/12898896/83078895-decf6280-a037-11ea-95f3-04c921cfb1aa.png)

The filmstrip sections do appear to be fixed so they aren't sliding behind the vertical menu bar, but I'm also wondering if we need to more specifically check different sections to ensure the left-alignment edge is exactly what we want. i.e. on this page i'm curious if these 2 sections are needing to move slightly to the left to align with other blocks, or if they are correct as shown here:
http://earth.lvh.me/geophysics#gs.pj2hmk
![image](https://user-images.githubusercontent.com/12898896/83079182-8351a480-a038-11ea-831e-13a0ca8697d4.png)
![image](https://user-images.githubusercontent.com/12898896/83079238-a1b7a000-a038-11ea-91ca-44938cea826c.png)
