### PR TITLE
Earth 1438 media fixes

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -3936,16 +3936,17 @@ ul.tabs {
       background-color: #8c1515;
       left: 0; }
     .field-p-wysiwyg h2::after {
-      top: .7em; }
+      top: 0.7em; }
   .field-p-wysiwyg h3 {
     font-size: 1.6em; }
   .field-p-wysiwyg figure {
     display: table;
-    margin-bottom: 30px; }
+    margin-bottom: 10px;
+    margin-top: 10px; }
     .field-p-wysiwyg figure.align-right {
-      margin-left: 30px; }
+      margin-left: 15px; }
     .field-p-wysiwyg figure.align-left {
-      margin-right: 30px; }
+      margin-right: 15px; }
   .field-p-wysiwyg figure.align-left img[data-responsive-image-style="landscape"],
   .field-p-wysiwyg figure.align-left img[data-responsive-image-style="portrait"],
   .field-p-wysiwyg figure.align-right img[data-responsive-image-style="landscape"],
@@ -3955,9 +3956,10 @@ ul.tabs {
     display: table-caption;
     caption-side: bottom;
     color: #4d4f53;
-    text-align: left; }
+    text-align: left;
+    font-size: 16px; }
   .field-p-wysiwyg img {
-    margin-bottom: 20px; }
+    margin-bottom: 5px; }
     .field-p-wysiwyg img.align-right {
       margin-left: 20px; }
     .field-p-wysiwyg img.align-left {
@@ -3992,11 +3994,25 @@ ul.tabs {
     padding: 15px;
     margin: 15px; }
   .field-p-wysiwyg div.well-insert-right {
-    background-color: #F9F6EF;
+    background-color: #f9f6ef;
     float: right;
     clear: none;
     width: 30%;
     padding: 15px;
     margin: 15px; }
+
+.stanford-wysiwyg .align-right .media--type-image picture {
+  margin-top: 10px;
+  margin-bottom: 10px;
+  margin-left: 15px; }
+
+.stanford-wysiwyg .align-left .media--type-image picture {
+  margin-top: 10px;
+  margin-bottom: 10px;
+  margin-right: 15px; }
+
+.stanford-wysiwyg .align-center .media--type-image picture {
+  margin-top: 10px;
+  margin-bottom: 10px; }
 
 /*# sourceMappingURL=components.css.map */

--- a/css/theme/stanford-news.css
+++ b/css/theme/stanford-news.css
@@ -321,14 +321,16 @@ h1 {
 .field--responsive-image picture,
 .field--responsive-video,
 .field-p-responsive-media picture,
-figure.align-center .figure-container {
+figure.align-center .figure-container,
+.stanford-wysiwyg figure.align-center {
   display: block;
   margin-bottom: 20px;
   position: relative; }
   .field--responsive-image picture::after,
   .field--responsive-video::after,
   .field-p-responsive-media picture::after,
-  figure.align-center .figure-container::after {
+  figure.align-center .figure-container::after,
+  .stanford-wysiwyg figure.align-center::after {
     content: '';
     background-color: #F9F6EF;
     position: absolute;
@@ -343,7 +345,8 @@ figure.align-center .figure-container {
   .field--responsive-image picture img,
   .field--responsive-video img,
   .field-p-responsive-media picture img,
-  figure.align-center .figure-container img {
+  figure.align-center .figure-container img,
+  .stanford-wysiwyg figure.align-center img {
     display: block;
     margin-bottom: 0;
     max-width: none;

--- a/css/theme/stanford-spotlight.css
+++ b/css/theme/stanford-spotlight.css
@@ -208,7 +208,7 @@ figcaption {
   caption-side: bottom;
   color: #4d4f53;
   display: table-caption;
-  text-align: right; }
+  text-align: left; }
 
 .lead-text {
   font-size: 22px;
@@ -273,7 +273,7 @@ figcaption {
 .content-type__media-container.left-align-media .content-type__media .photo-credit, .content-type__media-container.centered-media .content-type__media .photo-credit {
   clear: both;
   color: #4d4f53;
-  font-size: .8em;
+  font-size: 0.8em;
   line-height: 1.1em;
   margin: 10px 30px 10px 0;
   text-align: left; }

--- a/patterns/molecules/hero-banner/css/hero-banner.component.css
+++ b/patterns/molecules/hero-banner/css/hero-banner.component.css
@@ -8,7 +8,7 @@
 .hero-banner {
   position: relative; }
   .hero-banner.has-tint .image::before {
-    content: '';
+    content: "";
     display: block;
     background-color: rgba(0, 0, 0, 0.35);
     position: absolute;
@@ -36,6 +36,8 @@
     pointer-events: none; }
   .hero-banner.has-video.component-centered-container-margins .video {
     margin-bottom: 4.4615384615em; }
+  .hero-banner article.contextual-region {
+    position: unset; }
 
 .hero-banner__inner {
   position: relative;

--- a/patterns/molecules/hero-banner/scss/hero-banner.component.scss
+++ b/patterns/molecules/hero-banner/scss/hero-banner.component.scss
@@ -3,19 +3,55 @@
 ////
 
 // Decant
-@import 'decanter/core/utilities/decanter-utilities';
+@import "decanter/core/utilities/decanter-utilities";
 
 // Grab our mixins & config.
-@import 'patterns/utilities/utilities';
+@import "patterns/utilities/utilities";
 
 // OOO Issue with the variables being translated too early.
 $default-container: (
-  xs: (columns: 12, grid-media: $media-xs-only,  v-space: 1em, max-width: false, grid-collapse: false),
-  sm: (columns: 12, grid-media: $media-sm-only,  v-space: 1em, max-width: false, grid-collapse: false),
-  md: (columns: 12, grid-media: $media-md-only,  v-space: 1em, max-width: false, grid-collapse: false),
-  lg: (columns: 12, grid-media: $media-lg-only,  v-space: 1em, max-width: false, grid-collapse: false),
-  xl: (columns: 12, grid-media: $media-xl,       v-space: 1em, max-width: true,  grid-collapse: false),
-  print: (columns: 12, grid-media: $media-print, v-space: 1em, max-width: false, grid-collapse: false),
+  xs: (
+    columns: 12,
+    grid-media: $media-xs-only,
+    v-space: 1em,
+    max-width: false,
+    grid-collapse: false
+  ),
+  sm: (
+    columns: 12,
+    grid-media: $media-sm-only,
+    v-space: 1em,
+    max-width: false,
+    grid-collapse: false
+  ),
+  md: (
+    columns: 12,
+    grid-media: $media-md-only,
+    v-space: 1em,
+    max-width: false,
+    grid-collapse: false
+  ),
+  lg: (
+    columns: 12,
+    grid-media: $media-lg-only,
+    v-space: 1em,
+    max-width: false,
+    grid-collapse: false
+  ),
+  xl: (
+    columns: 12,
+    grid-media: $media-xl,
+    v-space: 1em,
+    max-width: true,
+    grid-collapse: false
+  ),
+  print: (
+    columns: 12,
+    grid-media: $media-print,
+    v-space: 1em,
+    max-width: false,
+    grid-collapse: false
+  )
 );
 
 // Variables.
@@ -30,10 +66,25 @@ $hero-max-width: 1380px;
 /// @require $neat-grid
 ///
 /// @link http://neat.bourbon.io Neat
-@mixin centered-abs-container($columns: null, $v-space: 1em, $max-width: false, $grid-collapse: false, $grid: $neat-grid) {
-  $columns: _neat-column-default($grid, $columns); // Retrieves max columns from specified grid if empty, or the specified number of columns otherwise
-  $_grid-columns: _retrieve-neat-setting($grid, columns); // Retrieves the number of max columns from the specified grid
-  $_grid-gutter: _retrieve-neat-setting($grid, gutter); // Retrieves the gutter from the specified grid
+@mixin centered-abs-container(
+  $columns: null,
+  $v-space: 1em,
+  $max-width: false,
+  $grid-collapse: false,
+  $grid: $neat-grid
+) {
+  $columns: _neat-column-default(
+    $grid,
+    $columns
+  ); // Retrieves max columns from specified grid if empty, or the specified number of columns otherwise
+  $_grid-columns: _retrieve-neat-setting(
+    $grid,
+    columns
+  ); // Retrieves the number of max columns from the specified grid
+  $_grid-gutter: _retrieve-neat-setting(
+    $grid,
+    gutter
+  ); // Retrieves the gutter from the specified grid
 
   @include grid-container;
   @if $grid-collapse == true {
@@ -55,11 +106,16 @@ $hero-max-width: 1380px;
     $_grid-collapse: map-get($_map, grid-collapse);
 
     @include grid-media($_grid) {
-      @include centered-abs-container($_cols, $_v-space, $_max-width, $_grid-collapse, $_grid);
+      @include centered-abs-container(
+        $_cols,
+        $_v-space,
+        $_max-width,
+        $_grid-collapse,
+        $_grid
+      );
     }
   }
 }
-
 
 // Styles
 
@@ -78,7 +134,7 @@ $hero-max-width: 1380px;
   &.has-tint {
     .image::before {
       @extend %absolute-fill;
-      content: '';
+      content: "";
       display: block;
       background-color: rgba(0, 0, 0, 0.35);
       position: absolute;
@@ -117,6 +173,10 @@ $hero-max-width: 1380px;
         margin-bottom: em(58px);
       }
     }
+  }
+
+  article.contextual-region {
+    position: unset;
   }
 }
 

--- a/scss/components/wysiwyg/_wysiwyg.scss
+++ b/scss/components/wysiwyg/_wysiwyg.scss
@@ -39,7 +39,7 @@
     @include dash-left-offset;
     font-size: 1.8em;
     &::after {
-      top: .7em;
+      top: 0.7em;
     }
   }
 
@@ -50,14 +50,15 @@
   // Floated images
   figure {
     display: table;
-    margin-bottom: 30px;
+    margin-bottom: 10px;
+    margin-top: 10px;
 
     &.align-right {
-      margin-left: 30px;
+      margin-left: 15px;
     }
 
     &.align-left {
-      margin-right: 30px;
+      margin-right: 15px;
     }
   }
 
@@ -74,10 +75,11 @@
     caption-side: bottom;
     color: color(stone);
     text-align: left;
+    font-size: 16px;
   }
 
   img {
-    margin-bottom: 20px;
+    margin-bottom: 5px;
 
     &.align-right {
       margin-left: 20px;
@@ -116,7 +118,7 @@
     clear: both;
   }
 
-//Special styles for Barb to use
+  //Special styles for Barb to use
   h3.teal,
   h2.teal {
     color: color(action);
@@ -137,11 +139,30 @@
   }
 
   div.well-insert-right {
-    background-color: #F9F6EF;
+    background-color: #f9f6ef;
     float: right;
     clear: none;
     width: 30%;
     padding: 15px;
     margin: 15px;
+  }
+}
+
+.stanford-wysiwyg {
+  .align-right .media--type-image picture {
+    margin-top: 10px;
+    margin-bottom: 10px;
+    margin-left: 15px;
+  }
+
+  .align-left .media--type-image picture {
+    margin-top: 10px;
+    margin-bottom: 10px;
+    margin-right: 15px;
+  }
+
+  .align-center .media--type-image picture {
+    margin-top: 10px;
+    margin-bottom: 10px;
   }
 }

--- a/scss/theme/stanford-news.scss
+++ b/scss/theme/stanford-news.scss
@@ -4,7 +4,8 @@
 // top of the page each time a complex page is rendered. A few things have to
 // move around to ensure that the banner is in the right place.
 
-.field-s-news-top-media #hero-banner:not(.component-centered-container-margins) {
+.field-s-news-top-media
+  #hero-banner:not(.component-centered-container-margins) {
   margin-top: -170px;
   @include grid-media($header-md) {
     margin-top: -176px;
@@ -221,7 +222,8 @@ h1 {
 .field--responsive-image picture,
 .field--responsive-video,
 .field-p-responsive-media picture,
-figure.align-center .figure-container {
+figure.align-center .figure-container,
+.stanford-wysiwyg figure.align-center {
   display: block;
   margin-bottom: 20px;
   position: relative;
@@ -243,7 +245,6 @@ figure.align-center .figure-container {
     @include dash-left-offset;
     margin-bottom: 20px;
   }
-
 }
 
 .field-p-responsive-image-cred {
@@ -325,14 +326,16 @@ figure.align-center .figure-container {
   }
 }
 
-.field-s-news-rich-content .ptype-stanford-wysiwyg:first-of-type .field-p-wysiwyg {
+.field-s-news-rich-content
+  .ptype-stanford-wysiwyg:first-of-type
+  .field-p-wysiwyg {
   // Drop Cap
   > p:first-of-type::first-line {
     font-size: 1em;
     letter-spacing: normal;
     position: relative;
   }
-    letter-spacing: normal;
+  letter-spacing: normal;
 
   > p:first-child::first-letter {
     float: left;

--- a/scss/theme/stanford-news.scss
+++ b/scss/theme/stanford-news.scss
@@ -326,9 +326,7 @@ figure.align-center .figure-container,
   }
 }
 
-.field-s-news-rich-content
-  .ptype-stanford-wysiwyg:first-of-type
-  .field-p-wysiwyg {
+.field-s-news-rich-content .ptype-stanford-wysiwyg:first-of-type .field-p-wysiwyg {
   // Drop Cap
   > p:first-of-type::first-line {
     font-size: 1em;

--- a/scss/theme/stanford-spotlight/stanford-spotlight.scss
+++ b/scss/theme/stanford-spotlight/stanford-spotlight.scss
@@ -18,7 +18,6 @@
 }
 
 .page-subtitle {
-
   h2 {
     font-size: 28px;
   }
@@ -36,7 +35,7 @@ figcaption {
   caption-side: bottom;
   color: color(stone);
   display: table-caption;
-  text-align: right;
+  text-align: left;
 }
 
 .lead-text {
@@ -58,7 +57,6 @@ figcaption {
 }
 
 .content-type__media-container {
-
   @include grid-media($media-lg) {
     margin-top: 50px;
     outline: 1px solid #999;
@@ -67,7 +65,6 @@ figcaption {
 
   &.left-align-media,
   &.centered-media {
-
     .content-type__header {
       &::after {
         clear: none;
@@ -97,7 +94,7 @@ figcaption {
       .photo-credit {
         clear: both;
         color: color(stone);
-        font-size: .8em;
+        font-size: 0.8em;
         line-height: 1.1em;
         margin: 10px 30px 10px 0;
         text-align: left;
@@ -107,7 +104,7 @@ figcaption {
         }
 
         &::after {
-          @include dash-under ($dash-color: brand);
+          @include dash-under($dash-color: brand);
         }
       }
     }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Updating Media module messed up image styles in a few places.

# Needed By (Date)
- When we push updated media

# Urgency
- Comparatively important compared to what I usually push. :)

# Steps to Test

1. Pull down this branch
2. Make sure you are on the branch with media management updates, or follow along by testing resulting css on https://se3-dev.stanford.edu/
3. Then check the following:

- Can you see banners on the EM page and any news pages?
- Can you see a sandstone bg on centered inline images, such as : (/news/steaming-cauldron-follows-dinosaurs-demise)
- Check caption alignment /events/sample-event
- Try centering an inline image on a news page or elsewhere. does it center?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- This replaces the Inline images & captions CSS injector rule

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)