### PR TITLE
EARTH-1407-blazy-and-inline-images

### DIFF
--- a/templates/fields/image.html.twig
+++ b/templates/fields/image.html.twig
@@ -10,5 +10,4 @@
  * @see template_preprocess_image()
  */
 #}
-{% set attributes = attributes.addClass("b-lazy") %}
-<img{{ attributes }} />
+<img{{ attributes.setAttribute('loading', 'lazy') }} />


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Replacing b-lazy class with loading attribute to use native lazy-loading instead of the Blazy library.

# Needed By (Date)
- Nest push

# Steps to Test

1. Load the homepage
2. Inspect any of the Our Community images
3. Verify that they have loading="lazy"
4. Open a network panel and reload the homepage
5. Scroll the page and verify that the Our Community pages do not load until you get to that part of the page.

# Associated Issues and/or People
- JIRA ticket EARTH-1407

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
