### PR TITLE
Earth 1439 empty headers

### DIFF
--- a/patterns/atoms/link-item/link-item.html.twig
+++ b/patterns/atoms/link-item/link-item.html.twig
@@ -6,7 +6,10 @@
 #}
 {# Set title to false so it doesnt change, since the text will be sufficient #}
 {{ link|openlink({class: 'link-item', title: false}) }}
-  <span class="link-item__title">{{ title }}
+  <span class="link-item__title">
+    {% if title is not empty %}
+    {{ title }}
+    {% endif %}
     {% if subtitle is not empty %}
     <span class="link-item__subtitle">{{ subtitle }}</span>
     {% endif %}

--- a/patterns/molecules/highlight-card/highlight-card.html.twig
+++ b/patterns/molecules/highlight-card/highlight-card.html.twig
@@ -12,7 +12,9 @@
     <span class="highlight-card__intro">{{ intro }}</span>
     {% endif %}
 
+    {% if title is not empty %}
     <h4 class="highlight-card__title">{{ title }}</h4>
+    {% endif %}
 
     {% if sub_title is not empty %}
     <h5>{{ sub_title }}</h5>

--- a/patterns/molecules/highlight-card/highlight-card.html.twig
+++ b/patterns/molecules/highlight-card/highlight-card.html.twig
@@ -12,7 +12,7 @@
     <span class="highlight-card__intro">{{ intro }}</span>
     {% endif %}
 
-    {% if title is not empty %}
+    {% if title|render|striptags|trim is not empty %}
     <h4 class="highlight-card__title">{{ title }}</h4>
     {% endif %}
 

--- a/patterns/molecules/simple-block/simple-block.html.twig
+++ b/patterns/molecules/simple-block/simple-block.html.twig
@@ -39,7 +39,7 @@
   {% endif %}
   <div class="simple-block__content">
 
-    {% if title is not empty %}
+    {% if title|render|striptags|trim is not empty %}
       <h3 class="simple-block__title">{{ link|openlink({class:"simple-block__link"}) }}{{ title }}{{ link|closelink }}</h3>
     {% endif %}
 

--- a/templates/stanford_event/stanford-event.html.twig
+++ b/templates/stanford_event/stanford-event.html.twig
@@ -7,7 +7,7 @@
 
   <div class="content-type__header">
     <div class="page-title"><h1>{{ title }}</h1></div>
-      {% if sub_title is not empty %}
+      {% if sub_title|render|striptags|trim is not empty %}
       <div class="page-subtitle">
         <h2>
           {{ sub_title }}

--- a/templates/stanford_spotlight/stanford-spotlight.html.twig
+++ b/templates/stanford_spotlight/stanford-spotlight.html.twig
@@ -30,6 +30,7 @@
 
     <div class="content-type__header">
       <div class="page-title"><h1>{{ title }}</h1></div>
+      {% if first_name|render|striptags|trim is not empty or last_name|render|striptags|trim is not empty or department|render|striptags|trim is not empty %}
       <div class="page-subtitle">
         <h2>
           {% if first_name is not empty or last_name is not empty %}
@@ -43,7 +44,8 @@
           {% endif %}
         </h2>
       </div>
-
+      {% endif %}
+      
       <div class="content-type-date">
         <span>{{ "Published"|t }}</span>
         <time>{{ created }}</time>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added/improved checks for variables so that fields do not get output if there is no text.  Specifically in this case with fields that output as headers.

# Needed By (Date)
- Next push

# Steps to Test

1. Create a test event and don't include a Subtitle
2. Inspect the output and verify that the field is not present.
3. Create a test Spotlight and don't include First Name, Last Name, or Department.
4. Inspect the output and verify that none of those fields are present.
5. Create a test News Item
6. Include an Editorial Sidebar P/T and a Highlight Card P/T.
7. Don't include a Title for the Editorial Sidebar nor a Subtitle for the Hightlight Card.
8. Inspect the output and verify that none of those fields are present.

# Associated Issues and/or People
- JIRA ticket EARTH-1439

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
