### PR TITLE
EARTH-1459:Switch Earth Matters subscription URL

### DIFF
--- a/templates/components/global-footer/global-footer.html.twig
+++ b/templates/components/global-footer/global-footer.html.twig
@@ -33,7 +33,7 @@
     <div class="contact-footer__subscribe">
       <h2>{{ 'Subscribe to Stanford Earth Matters'|trans }}</h2>
       <p>{{ 'Our Monthly Research News Alert'|trans }}</p>
-      <a class="button__hollow" href="https://stanford.us7.list-manage.com/subscribe/post?u=167e9da7acec83c4cc802b3e7&id=69d6fa9e3a">Subscribe</a>
+      <a class="button__hollow" href="/earth-matters/subscribe">Subscribe</a>
     </div>
 
 

--- a/templates/stanford_news/field--node--field-s-news-date.html.twig
+++ b/templates/stanford_news/field--node--field-s-news-date.html.twig
@@ -47,7 +47,7 @@
 
 {% if is_earth_matters %}
 <div class="subscribe-wrapper">
-  <a href="https://stanford.us7.list-manage.com/subscribe/post?u=167e9da7acec83c4cc802b3e7&id=69d6fa9e3a" class="button btn">
+  <a href="/earth-matters/subscribe" class="button btn">
     <span class="sup">{{ 'Know your planet.'|t }}</span>
     <span>{{ 'Subscribe'|t }}</span>
     <span class="suf">{{ 'Stanford Earth Matters Magazine'|t }}</span>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- TL;DR - Switched Earth Matters subscription URL from Mailchimp pages to a local page

# Needed By (Date)
- Next production push

# Steps to Test

1. Verify that the "Subscribe" button in the universal footer links to /earth-matters/subscribe.
2. Verify that the "Subscribe" button on any news article links to /earth-matters/subscribe.

# Associated Issues and/or People
- JIRA ticket EARTH-1459

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
