### PR TITLE
EARTH-1499: adding button padding and color to button in view

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -2627,6 +2627,9 @@ html .getsocial {
       background-color: #4d4f53;
       color: #fff;
       text-decoration: none; }
+    .pager__item a.button {
+      color: #fff;
+      padding: 20px; }
   .pager__item.is-active a, .pager__item.pager__item--active a {
     background-color: #8c1515;
     box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.25);

--- a/scss/components/pager/_pager.scss
+++ b/scss/components/pager/_pager.scss
@@ -38,6 +38,12 @@
       color: color(white);
       text-decoration: none;
     }
+
+//infinite scroll button for views to match load more on EM
+    &.button {
+      color: color(white);
+      padding: 20px;
+    }
   }
 
   &.is-active,


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
-The load more button on the Earth directory page had insufficient contrast and padding.

# Needed By (Date)
- No rush

# Steps to Test

1. Pull down this branch
2. go to about/directory
3. Scroll to bottom and check out the load more button

# Affected versions or modules
- Does this PR impact any particular module, version, or pull request?

# Associated Issues and/or People
- JIRA ticket EARTH-1499


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
