### PR TITLE
Switching skip link from naviation to main content.

### DIFF
--- a/templates/html.html.twig
+++ b/templates/html.html.twig
@@ -55,8 +55,8 @@
   <body{{ attributes.addClass(classes) }}>
   {% spaceless %}
     <div id="skip">
-      <a href="#main-menu" class="visually-hidden focusable skip-link">
-        {{ 'Skip to main navigation'|t }}
+      <a href="#block-matson-content" class="visually-hidden focusable skip-link">
+        {{ 'Skip to content'|t }}
       </a>
     </div>
     {% include "@matson/components/brand-bar/brand-bar.html.twig" with {'brandbar': page.brandbar} %}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- TL;DR - Pointing the skip link to the main content

# Needed By (Date)
- Next push

# Steps to Test

1. Open Chrome (Skip link seems to be broken in Firefox and Safari)
2. Select the TAB key
3. The first link should say "Skip to content"
4. Select ENTER
5. Focus should be on the main content area and not the main navigation.


# Associated Issues and/or People
- JIRA ticket EARTH-1507

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
