### PR TITLE
Removing white text as this is handled elsewhere

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -2213,10 +2213,7 @@ html .getsocial {
   -moz-osx-font-smoothing: grayscale; }
 
 .masonry-block__link {
-  color: #FFF; }
-  @media only screen and (min-width: 576px) {
-    .masonry-block__link {
-      color: #4d4f53; } }
+  color: #4d4f53; }
   .masonry-block__link:hover, .masonry-block__link:active, .masonry-block__link:focus {
     color: inherit;
     text-decoration: none; }

--- a/scss/components/masonry-block/_masonry-block.scss
+++ b/scss/components/masonry-block/_masonry-block.scss
@@ -201,10 +201,7 @@
 }
 
 .masonry-block__link {
-  color: #FFF;
-  @include grid-media($media-sm) {
-    color: color(text-active);
-  }
+  color: color(text-active);
   @include on-event {
     color: inherit;
     text-decoration: none;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fix issue where titles on white backgrounds were invisible and some titles were light gray

# Needed By (Date)
- Next production push

# Steps to Test

1. Disable this CSS Injector Rule: "Earth Matters Responsive Temp Fixes"
2. Navigate to /earth-matters
3. Set your window size to mobile width 
4. Review all teaser titles and verify that they are either black or white.

# Associated Issues and/or People
- JIRA ticket EARTH-1501

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
