### PR TITLE
Add class to Earth Matters News pages

### DIFF
--- a/matson.theme
+++ b/matson.theme
@@ -77,10 +77,18 @@ function matson_preprocess_field_field_s_news_date(&$variables, $hook) {
 }
 
 /**
- * Prepares non node/panel pages to be in a single column.
+ * Add 'earth-matters' class to all Earth Matters news items.
  */
 function matson_preprocess_page(&$vars) {
-  // Nothing to see here.
+  if(
+    isset($vars['node']) && 
+    $vars['node'] instanceof \Drupal\node\NodeInterface && 
+    $vars['node']->bundle() == 'stanford_news' &&
+    $vars['node']->get('field_s_news_category')->getString() == '81'
+    // TID 81 == Earth Matters.
+  ){
+    $vars['attributes']['class'][] = 'earth-matters';
+  }
 }
 
 /**

--- a/templates/page.html.twig
+++ b/templates/page.html.twig
@@ -1,8 +1,10 @@
 {% set main_menu = page.primary_menu|render %}
 {% set secondary_menu = page.secondary_menu|render %}
 
+
   <!-- ______________________ HEADER _______________________ -->
 
+<div{{ attributes }}>
   {% if page.highlighted|render is not empty %}
     <div id="highlighted">{{ page.highlighted }}</div>
   {% endif %}
@@ -53,3 +55,4 @@
       {{ page.footer }}
     </footer><!-- /#footer -->
   {% endif %}
+</div>

--- a/templates/page.html.twig
+++ b/templates/page.html.twig
@@ -1,7 +1,6 @@
 {% set main_menu = page.primary_menu|render %}
 {% set secondary_menu = page.secondary_menu|render %}
 
-
   <!-- ______________________ HEADER _______________________ -->
 
 <div{{ attributes }}>


### PR DESCRIPTION
# READY FOR REVIEW
- (Edit the above to reflect status)

# Summary
- Add a class to Earth Matters News pages

# Needed By (Date)
- When does this need to be merged by?

# Steps to Test
1. checkout this branch
2. navigate to a news page tagged with the Earth Matters news type
3. inspect the page and find that a div with the class of `earth-matters` has been added.
4. Navigate to page NOT tagged with the Earth Matters news type, inspect and see that the div does not contain a class of `earth-matters`.

# Affected versions or modules
- Does this PR impact any particular module, version, or pull request?

# Associated Issues and/or People
- [EARTH-1558](https://stanfordits.atlassian.net/browse/EARTH-1558): Add a class to Earth Matters News pages
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [Gitpod Workspace Snapshot](https://amethyst-leopard-re6on595.ws-us07.gitpod.io/)
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
