### PR TITLE
EARTH-1562: Remove extra styling for the  magazine section of logo

### DIFF
--- a/scss/components/earth-matters-footer/_earth-matters-footer.scss
+++ b/scss/components/earth-matters-footer/_earth-matters-footer.scss
@@ -59,12 +59,6 @@
       margin: 0;
     }
   }
-  
-  &__logo-2 {
-    font-weight: 400;
-    font-size: 4rem;
-    margin-left: 1rem;
-  }
 
   &__links-container {
     padding: 0 7rem 0 7rem;


### PR DESCRIPTION
# READY FOR REVIEW
- (Edit the above to reflect status)

# Summary
- TL;DR - Remove extra styling for the  magazine section of logo

# Needed By (Date)
- When does this need to be merged by?

# Steps to Test

1. Do this
2. Then this
3. Then this

# Affected versions or modules
- Does this PR impact any particular module, version, or pull request?

# Associated Issues and/or People
- JIRA ticket: [EARTH-1562](https://stanfordits.atlassian.net/browse/EARTH-1562)
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
