### PR TITLE
EARTH 1593: Remove incorrect styles

### DIFF
--- a/css/components/components.css
+++ b/css/components/components.css
@@ -1095,10 +1095,6 @@
     @media only screen and (max-width: 768px) {
       .earth-matters-footer__logo {
         margin: 0; } }
-  .earth-matters-footer__logo-2 {
-    font-weight: 400;
-    font-size: 4rem;
-    margin-left: 1rem; }
   .earth-matters-footer__links-container {
     padding: 0 7rem 0 7rem;
     display: grid;

--- a/css/layout/stanford-subsite.css
+++ b/css/layout/stanford-subsite.css
@@ -741,11 +741,8 @@
     width: calc(25% - 37.5px);
     float: left;
     margin-left: 30px; }
-    .section-tall-filmstrip .filmstrip.is-tall .film-card:nth-child(2), .section-tall-filmstrip .filmstrip.is-tall .film-card:nth-child(4), .section-tall-filmstrip .filmstrip.is-tall .film-card:nth-child(5n) {
-      margin-top: -2em; }
-    .section-tall-filmstrip .filmstrip.is-tall .film-card:nth-child(5n) {
-      margin-left: calc(25% - 37.5px + 60px);
-      clear: left; } }
+    .section-tall-filmstrip .filmstrip.is-tall .film-card:nth-child(2), .section-tall-filmstrip .filmstrip.is-tall .film-card:nth-child(4) {
+      margin-top: -2em; } }
 
 .section-tall-filmstrip .filmstrip__header .component-centered-container {
   padding-right: 0;

--- a/scss/layout/subsite/_section-tall-filmstrip.scss
+++ b/scss/layout/subsite/_section-tall-filmstrip.scss
@@ -20,14 +20,8 @@
           @include grid-column(3, $callout-filmstrip-flexible);
 
           &:nth-child(2),
-          &:nth-child(4),
-          &:nth-child(5n) {
+          &:nth-child(4) {
             margin-top: -2em;
-          }
-
-          &:nth-child(5n) {
-            @include grid-push(3, $callout-filmstrip-flexible);
-            clear: left;
           }
         }
       }


### PR DESCRIPTION
# READY FOR REVIEW
- (Edit the above to reflect status)

# Summary
- [EARTH-1593](https://stanfordits.atlassian.net/browse/EARTH-1593): FE | Tall filmstrip issues
- The tall filmstrip was appearing incorrect after two lines due to a `clear: left;` styling that had been applied to `:nth-child(5n)` in `_section-tall-filmstrip.scss`. This applies that styling to every fifth element (not including the first one) - but since the filmstrip is 4 per row not 5, the correct styling would actually be `:nth-child(4n+5) {
          clear: left;
        }`. Those styles had actually already been added to the `filmstrip.component.scss`, but were being written over by the incorrect `5n` styles. So I just removed the `5n` styling to fix the issue.
- I also noticed that the 15th element also had some `margin-top` issues due to a similar incorrect `5n` style. I went ahead and removed that to fix that issue as well.
![Screen Shot 2021-10-14 at 12 55 00 PM](https://user-images.githubusercontent.com/49299083/137389200-9954a659-6045-45fc-a38f-9f4c4a35e658.png)

# Needed By (Date)
- When does this need to be merged by?

# Steps to Test

1. Checkin the branch
2. Navigate to `/ere/welcome-orientation` and check to see if the grid is working as desired. You may need to inspect the 10th element, and remove the `clear: none` to make sure that my solution works - the `clear: none;` added to that element was the previous solution to this issue, and had to be added manually via CSS injector. This should now work without that code applied.

# Affected versions or modules
- Does this PR impact any particular module, version, or pull request?

# Associated Issues and/or People
- JIRA ticket SE3:-
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
