### PR TITLE
EARTH 1626: Localist updates for event details page

### DIFF
--- a/templates/stanford_event/stanford-event.html.twig
+++ b/templates/stanford_event/stanford-event.html.twig
@@ -62,9 +62,19 @@
         </dd>
         {% endif %}
         {% if sponsor|render|striptags|trim is not empty %}
-        <dt>{{ 'Sponsor'|t }}:</dt>
+        <dt>{{ 'Sponsors'|t }}:</dt>
         <dd>
+        {% if sponsor is iterable %}
+        {% set rendered_sponsor = "" %}
+          {% for field in sponsor %}
+            {% for key, item in field if key|first != '#' %}
+              {% set rendered_sponsor = rendered_sponsor ~ "#{item|render}, "  %}
+            {% endfor %}
+          {% endfor %}
+          {{ rendered_sponsor|trim|slice(0, -1)|raw }}
+        {% else %}
           {{ sponsor }}
+        {% endif %}
         </dd>
         {% endif %}
       </dl>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
Update event detail page to account for situations where there are multiple sponsors.

Previous:
![Screen Shot 2022-03-14 at 4 45 13 PM](https://user-images.githubusercontent.com/49299083/158279459-1363c048-0312-404a-9ae2-4a5bebca8491.png)

Updated:
<img width="375" alt="Screen Shot 2022-03-14 at 4 48 16 PM" src="https://user-images.githubusercontent.com/49299083/158279476-59fd5f86-a29f-4914-8ae6-bc4702b8e81b.png">

- [EARTH-1626](https://stanfordits.atlassian.net/browse/EARTH-1626): Update Event C/T detail page template with all Localist fields

# Needed By (Date)
- When does this need to be merged by?

# Steps to Test

1. Do this
2. Then this
3. Then this

# Affected versions or modules
- Does this PR impact any particular module, version, or pull request?

# Associated Issues and/or People
- [EARTH-1626](https://stanfordits.atlassian.net/browse/EARTH-1626): Update Event C/T detail page template with all Localist fields
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
